### PR TITLE
api: fix a typo in disruption status check

### DIFF
--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -308,7 +308,7 @@ def get_uuid(value, name):
 
 
 def send_disruption_to_navitia(disruption):
-    if disruption.is_published:
+    if disruption.is_published():
         feed_entity = populate_pb(disruption)
         chaos.publisher.publish(
             feed_entity.SerializeToString(),


### PR DESCRIPTION
fixing typo in is_published() function call.