### PR TITLE
Bugfix rzo 301 manage return when no publish to rabbitmq

### DIFF
--- a/chaos/publisher.py
+++ b/chaos/publisher.py
@@ -2,7 +2,6 @@ from kombu import Connection, Exchange
 from kombu.pools import producers
 import logging
 import socket
-import sys
 from gevent import spawn_later
 
 
@@ -15,7 +14,7 @@ class Publisher(object):
             return
 
         self._connection = Connection(connection_string)
-        self._connections = set([self._connection])#set of connection for the heartbeat
+        self._connections = set([self._connection])  # set of connection for the heartbeat
         self._exchange = Exchange(exchange, durable=True, delivry_mode=2, type='topic')
         self._connection.connect()
         monitor_heartbeats(self._connections)
@@ -36,7 +35,7 @@ class Publisher(object):
                 publish(item, exchange=self._exchange, routing_key=contributor, declare=[self._exchange])
             except:
                 self.is_connected = False
-                logging.exception("Impossible to publish message to rabbitmq !")
+                logging.exception("Impossible to publish message to rabbitmq")
             finally:
                 return self.is_connected
 
@@ -59,7 +58,7 @@ class Publisher(object):
 
 def monitor_heartbeats(connections, rate=2):
     """
-    launch the heartbeat of amqp, it's mostly for prevent the f@#$ firewall from droping the connection
+    launch the heartbeat of amqp, it's mostly for prevent the f@#$ firewall from dropping the connection
     """
     supports_heartbeats = False
     interval = 10000
@@ -81,8 +80,8 @@ def monitor_heartbeats(connections, rate=2):
                 try:
                     conn.heartbeat_check(rate=rate)
                 except socket.error:
-                    logging.getLogger(__name__).info('connection %s dead: closing it!', conn)
-                    #actualy we don't do a close(), else we won't be able to reopen it after...
+                    logging.getLogger(__name__).info('connection %s dead : closing it !', conn)
+                    # actually we don't do a close(), else we won't be able to reopen it after...
                     to_remove.append(conn)
             else:
                 to_remove.append(conn)

--- a/chaos/publisher.py
+++ b/chaos/publisher.py
@@ -36,8 +36,7 @@ class Publisher(object):
                 publish(item, exchange=self._exchange, routing_key=contributor, declare=[self._exchange])
             except:
                 self.is_connected = False
-                err = sys.exec_info()[0]
-                logging.getLogger(__name__).debug("Impossible to publish message to rabbitmq !, error : %s" % err)
+                logging.exception("Impossible to publish message to rabbitmq !")
             finally:
                 return self.is_connected
 

--- a/chaos/publisher.py
+++ b/chaos/publisher.py
@@ -82,7 +82,7 @@ def monitor_heartbeats(connections, rate=2):
                 try:
                     conn.heartbeat_check(rate=rate)
                 except socket.error:
-                    logging.getLogger(__name__).info('connection %s dead : closing it !', conn)
+                    logging.getLogger(__name__).info('connection %s dead: closing it !', conn)
                     # actually we don't do a close(), else we won't be able to reopen it after...
                     to_remove.append(conn)
             else:

--- a/chaos/publisher.py
+++ b/chaos/publisher.py
@@ -26,6 +26,7 @@ class Publisher(object):
 
     def publish(self, item, contributor):
         if not self._is_active:
+            logging.getLogger(__name__).info('RabbitMQ is not enabled')
             return True
 
         with self._get_producer() as producer:
@@ -33,6 +34,7 @@ class Publisher(object):
                 self.is_connected = True
                 publish = producer.connection.ensure(producer, producer.publish, max_retries=3)
                 publish(item, exchange=self._exchange, routing_key=contributor, declare=[self._exchange])
+                logging.getLogger(__name__).info('Publishing message on exchange %s', self._exchange.name)
             except:
                 self.is_connected = False
                 logging.exception("Impossible to publish message to rabbitmq")

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -263,7 +263,7 @@ class Disruptions(flask_restful.Resource):
             db.session.delete(disruption)
             db.session.commit()
             return marshal({'error': {'message': '{}'.format(e.message)}}, fields.error_fields), 503
-        except e:
+        except Exception, e:
             db.session.rollback()
             return marshal({'error': {'message': '{}'.format(e.message)}}, fields.error_fields), 500
 
@@ -687,7 +687,7 @@ class Impacts(flask_restful.Resource):
                            error_fields), 400
 
         json = request.get_json(silent=True)
-        logging.getLogger(__name__).debug('POST impcat: %s', json)
+        logging.getLogger(__name__).debug('POST impact: %s', json)
 
         try:
             validate(json, impact_input_format)

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -335,7 +335,7 @@ class Disruptions(flask_restful.Resource):
                 return marshal(
                     {'error': {'message': 'An error occurred during transferring\
 this disruption to Navitia. Please try again.'}}, error_fields), 503
-        except e:
+        except Exception, e:
             db.session.rollback()
             return marshal(
                 {'error': {'message': '{}'.format(e.message)}},
@@ -718,7 +718,7 @@ class Impacts(flask_restful.Resource):
             db.session.delete(impact)
             db.session.commit()
             return marshal({'error': {'message': '{}'.format(e.message)}}, fields.error_fields), 503
-        except e:
+        except Exception, e:
             db.session.rollback()
             return marshal(
                 {'error': {'message': '{}'.format(e.message)}},
@@ -760,7 +760,7 @@ class Impacts(flask_restful.Resource):
                 return marshal(
                     {'error': {'message': 'An error occurred during transferring\
 this impact to Navitia. Please try again.'}}, error_fields), 503
-        except e:
+        except Exception, e:
             db.session.rollback()
             return marshal(
                 {'error': {'message': '{}'.format(e.message)}},

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -309,7 +309,7 @@ def get_uuid(value, name):
 
 def send_disruption_to_navitia(disruption):
     if disruption.is_draft():
-        return False
+        return True
 
     feed_entity = populate_pb(disruption)
     return chaos.publisher.publish(

--- a/tests/disruption_test.py
+++ b/tests/disruption_test.py
@@ -119,6 +119,6 @@ def test_disruption_with_rabbitmq_exception():
 
     disruption.status = 'published'
     
-    chaos.publisher.publish = MagicMock(return_value=True)
+    chaos.publisher.publish = MagicMock(return_value=False)
     to_rabbitmq_not_sent = send_disruption_to_navitia(disruption)
     eq_(to_rabbitmq_not_sent, False)

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -3,7 +3,8 @@ import os
 #URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
-DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
+DATABASE_HOST = '192.168.99.100'
+#str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -3,8 +3,7 @@ import os
 #URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
-DATABASE_HOST = '192.168.99.100'
-#str(os.getenv('DATABASE_HOST', 'localhost'))
+DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'


### PR DESCRIPTION
# Description

This PR fix an error when the rabbitmq is down -> no perturbation set into navitia
## Issue (optional)

Issue link:
http://jira.canaltp.fr/browse/RZO-301
## Pull Request type (optional)

This is a bug fix
## How to test

Make a perturbation on the NMM TR with your rabbitmq down
Check that:
- an error is set on the logfile
- a message is shown on the NMM TR
- your perturbation is not saved on the chaos database.
## Team reviewers (optional)

@kinnou02 
