### PR TITLE
No more duplicate in disruptions list

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -541,7 +541,7 @@ class Disruption(TimestampMixin, db.Model):
                 query_line_section = query_line_section.filter(or_(*filters))
                 query = query.union_all(query_line_section)
 
-        return query.order_by(cls.end_publication_date)
+        return query.order_by(cls.end_publication_date, cls.id)
 
     @property
     def publication_status(self):

--- a/tests/features/list-disruptions-by-pt-object.feature
+++ b/tests/features/list-disruptions-by-pt-object.feature
@@ -319,5 +319,5 @@ Feature: list impacts by ptobject and/or uri(s)
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2
-        And the field "disruptions.0.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.1.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -246,7 +246,7 @@ Feature: list disruptions with pager
         Then the status code should be "200"
         And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
         And the field "disruptions.1.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
-        When I get "/disruptions?start_page=2&items_per_page=3"
+        When I get "/disruptions?start_page=3&items_per_page=2"
         Then the status code should be "200"
         And the field "disruptions.0.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"
 

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -228,6 +228,7 @@ Feature: list disruptions with pager
             | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 8ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
             | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 9ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
             | chien     |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 0ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | clown     |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 1ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
 
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
@@ -235,8 +236,17 @@ Feature: list disruptions with pager
         When I get "/disruptions"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
-        And the field "disruptions" should have a size of 4
+        And the field "disruptions" should have a size of 5
         And the field "disruptions.0.id" should be "0ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.1.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.2.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.3.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "1ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.2.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.3.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.4.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"
+        When I get "/disruptions?start_page=2&items_per_page=2"
+        Then the status code should be "200"
+        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
+        When I get "/disruptions?start_page=2&items_per_page=3"
+        Then the status code should be "200"
+        And the field "disruptions.0.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"
+

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -207,3 +207,36 @@ Feature: list disruptions with pager
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "items_per_page argument value is not valid"
+
+    Scenario: Use pager to order disruptions with identical end_publication_date
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | end_publication_date |cause_id                            | client_id                            | contributor_id                       |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 8ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 9ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | chien     |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 0ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-05-02T19:00:00 | 7ffab230-3d48-4eea-aa2c-22f8680230b6| 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 4
+        And the field "disruptions.0.id" should be "0ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.2.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.3.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"


### PR DESCRIPTION
# Description

This PR fixes bug RZO-334, duplicate in disruptions list when pagination is used

## How to test

Here are the following steps to test this pull request:

Connect yourself in NMM traffic report,
- go to realtime/disruptions view
- try to display all disruptions available (tou can select 'past' filter to get many disruptions in response, and pagination)

No duplicate must appear in list.