### PR TITLE
Optimize disruption list

### DIFF
--- a/chaos/api.py
+++ b/chaos/api.py
@@ -100,3 +100,12 @@ def error_handler(exception):
     log all exceptions not catch before
     """
     app.logger.exception('')
+
+if api.app.config.get('ACTIVATE_PROFILING'):
+    api.app.logger.warning('=======================================================')
+    api.app.logger.warning('activation of the profiling, all query will be slow !')
+    api.app.logger.warning('=======================================================')
+    from werkzeug.contrib.profiler import ProfilerMiddleware
+    api.app.config['PROFILE'] = True
+    f = open('/tmp/profiler.log', 'a+')
+    api.app.wsgi_app = ProfilerMiddleware(api.app.wsgi_app, f, restrictions=[80], profile_dir='/tmp/profile')

--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -18,6 +18,8 @@ EXCHANGE = 'navitia'
 
 ENABLE_RABBITMQ = True
 
+ACTIVATE_PROFILING = False
+
 # Log Level available
 # - DEBUG
 # - INFO
@@ -59,7 +61,7 @@ LOGGER = {
         },
         'sqlalchemy.engine': {
             'handlers': ['default'],
-            'level': 'WARN',
+            'level': 'INFO',
             'propagate': False
         },
         'sqlalchemy.pool': {

--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -61,7 +61,7 @@ LOGGER = {
         },
         'sqlalchemy.engine': {
             'handlers': ['default'],
-            'level': 'INFO',
+            'level': 'WARN',
             'propagate': False
         },
         'sqlalchemy.pool': {

--- a/chaos/fields.py
+++ b/chaos/fields.py
@@ -29,7 +29,7 @@
 
 from flask_restful import fields, url_for
 from flask import current_app, request
-from utils import make_pager, get_coverage, get_token, get_current_time
+from utils import make_fake_pager, get_coverage, get_token, get_current_time
 from chaos.navitia import Navitia
 from copy import deepcopy
 
@@ -63,7 +63,7 @@ class FieldPaginateImpacts(fields.Raw):
     Pagination of impacts list for one disruption
     '''
     def output(self, key, disruption):
-        return make_pager(disruption.impacts.paginate(1, 20),
+        return make_fake_pager(disruption.impacts.count(), 20,
                           'impact',
                           disruption_id=disruption.id)
 

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -103,7 +103,7 @@ def make_fake_pager(resultcount, per_page, endpoint, **kwargs):
 
     if resultcount > 0:
         last_link = url_for(endpoint,
-                            start_page=ceil(resultcount / per_page),
+                            start_page=int(ceil(float(resultcount) / per_page)),
                             items_per_page=per_page,
                             _external=True, **kwargs)
         first_link = url_for(endpoint,

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -40,6 +40,7 @@ from chaos.exceptions import HeaderAbsent
 import chaos
 import pytz
 import logging
+from math import ceil
 
 
 def make_pager(resultset, endpoint, **kwargs):
@@ -83,6 +84,46 @@ def make_pager(resultset, endpoint, **kwargs):
     }
     return result
 
+
+def make_fake_pager(resultcount, per_page, endpoint, **kwargs):
+    """
+        Generate a fake pager object only based on the object count
+        for the first page
+    """
+    prev_link = None
+    next_link = None
+    last_link = None
+    first_link = None
+
+    if resultcount > per_page:
+        next_link = url_for(endpoint,
+                            start_page=2,
+                            items_per_page=per_page,
+                            _external=True, **kwargs)
+
+    if resultcount > 0:
+        last_link = url_for(endpoint,
+                            start_page=ceil(resultcount / per_page),
+                            items_per_page=per_page,
+                            _external=True, **kwargs)
+        first_link = url_for(endpoint,
+                             start_page=1,
+                             items_per_page=per_page,
+                             _external=True, **kwargs)
+
+    result = {
+        "pagination": {
+            "start_page": 1,
+            "items_on_page": min(resultcount, per_page),
+            "items_per_page": per_page,
+            "total_result": resultcount,
+            "prev": {"href": prev_link},
+            "next": {"href": next_link},
+            "first": {"href": first_link},
+            "last": {"href": last_link}
+        }
+    }
+    return result
 
 class paginate(object):
     def __call__(self, func):

--- a/migrations/versions/d3eacac50a6_.py
+++ b/migrations/versions/d3eacac50a6_.py
@@ -1,0 +1,23 @@
+"""Add some indexes
+
+Revision ID: d3eacac50a6
+Revises: 2cd4af730af5
+Create Date: 2016-12-21 15:44:09.138657
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd3eacac50a6'
+down_revision = '2cd4af730af5'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('ix_disruption_contrib_status', 'disruption', ['contributor_id', 'status'], unique=False)
+    op.create_index('ix_impact_disruption_status', 'impact', ['disruption_id', 'status'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_disruption_contrib_status')
+    op.drop_index('ix_impact_disruption_status')


### PR DESCRIPTION
# Description

This PR lower execution time of disruption list route.
This is only a first step to optimize.

## How to test

Here are the following steps to test this pull request:

- upgrade DB
- Try to load a disruption list - eg /disruptions?publication_status%5B%5D=past&publication_status%5B%5D=ongoing&start_page=1&items_per_page=10
- The result should be the very same but should be faster

## Team reviewers (optional)

@pthegner @dvdn 
