### PR TITLE
Enable full customization via environment vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apk --update --no-cache add \
         git \
         postgresql-dev && \
     pip install -U pip && \
-    pip install --no-cache-dir uwsgi && \
     pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir uwsgi && \
     apk del \
         g++ \
         build-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,38 @@
-FROM debian:7.8
+FROM alpine:edge
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -yq install \
-        curl \
-        python2.7 \
-        python2.7-dev \
-        python-pip \
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+RUN echo http://dl-3.alpinelinux.org/alpine/edge/testing  >> /etc/apk/repositories
+
+RUN apk --update --no-cache add \
+        g++ \
+        build-base \
+        python-dev \
+        py2-pip \
+        zlib-dev \
+        linux-headers \
+        musl \
+        musl-dev \
         git \
-        libpq-dev \
-        wget \
-        netcat && \
-    rm -rf /var/lib/apt/lists/*
+        postgresql-dev && \
+    pip install -U pip && \
+    pip install --no-cache-dir uwsgi && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apk del \
+        g++ \
+        build-base \
+        python-dev \
+        zlib-dev \
+        linux-headers \
+        musl \
+        musl-dev
 
-ADD requirements.txt /tmp/requirements.txt
-RUN pip install -qr /tmp/requirements.txt
-RUN pip install -q honcho
+EXPOSE 5000
 
-RUN wget -qP /tmp https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
-RUN tar -xf /tmp/protobuf-2.6.1.tar.gz -C /var/lib/
-RUN cd /var/lib/protobuf-2.6.1 && \
-    ./configure && \
-    make && \
-    make install && \
-    ldconfig
-RUN rm -rf /tmp/*
+WORKDIR /usr/src/app/
 
-ADD docker/run.sh /run.sh
-RUN chmod 755 /run.sh
+ENV CHAOS_CONFIG_FILE=default_settings.py
+ENV PYTHONPATH=.
+CMD ["uwsgi", "--mount", "/=chaos:app", "--http", "0.0.0.0:5000"]
 
-# fix python encoding warning
-ENV PYTHONIOENCODING utf-8
-
-WORKDIR /var/www/Chaos
-
-EXPOSE 80
-
-CMD ["/run.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,38 @@
+FROM debian:7.8
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -yq install \
+        curl \
+        python2.7 \
+        python2.7-dev \
+        python-pip \
+        git \
+        libpq-dev \
+        wget \
+        netcat && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install -qr /tmp/requirements.txt
+RUN pip install -q honcho
+
+RUN wget -qP /tmp https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz
+RUN tar -xf /tmp/protobuf-2.6.1.tar.gz -C /var/lib/
+RUN cd /var/lib/protobuf-2.6.1 && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig
+RUN rm -rf /tmp/*
+
+ADD docker/run.sh /run.sh
+RUN chmod 755 /run.sh
+
+# fix python encoding warning
+ENV PYTHONIOENCODING utf-8
+
+WORKDIR /var/www/Chaos
+
+EXPOSE 80
+
+CMD ["/run.sh"]

--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -2,23 +2,21 @@ import os
 # URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 # http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
-DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos'
+SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@localhost/chaos'))
 
-DEBUG = True
+DEBUG = (os.getenv('DEBUG', 1) == 1)
 
-NAVITIA_URL = 'http://navitia2-ws.ctp.dev.canaltp.fr'
+NAVITIA_URL = str(os.getenv('NAVITIA_URL', 'http://navitia2-ws.ctp.dev.canaltp.fr'))
 
 # rabbitmq connections string: http://kombu.readthedocs.org/en/latest/userguide/connections.html#urls
-RABBITMQ_HOST = str(os.getenv('RABBITMQ_HOST', 'localhost'))
-RABBITMQ_CONNECTION_STRING = 'pyamqp://guest:guest@' + RABBITMQ_HOST + ':5672//?heartbeat=60'
+RABBITMQ_CONNECTION_STRING = str(os.getenv('RABBITMQ_CONNECTION_STRING', 'pyamqp://guest:guest@localhost:5672//?heartbeat=60'))
 
 # amqp exhange used for sending disruptions
-EXCHANGE = 'navitia'
+EXCHANGE = str(os.getenv('RABBITMQ_EXCHANGE', 'navitia'))
 
-ENABLE_RABBITMQ = True
+ENABLE_RABBITMQ = (os.getenv('RABBITMQ_ENABLED', 1) == 1)
 
-ACTIVATE_PROFILING = False
+ACTIVATE_PROFILING = (os.getenv('PROFILING_ENABLED', 0) == 1)
 
 # Log Level available
 # - DEBUG
@@ -54,9 +52,6 @@ LOGGER = {
     'loggers': {
         '': {
             'handlers': ['default'],
-            'level': 'DEBUG',
-        },
-        'amqp': {
             'level': 'DEBUG',
         },
         'sqlalchemy.engine': {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   ws:
     image: navitia/chaos-ws:dev
     environment:
-      - DATABASE_HOST=database
-      - RABBITMQ_HOST=rabbitmq
+      - SQLALCHEMY_DATABASE_URI=postgresql://navitia:navitia@database/chaos
+      - RABBITMQ_CONNECTION_STRING=pyamqp://guest:guest@rabbitmq:5672//?heartbeat=60
       - DOMAIN_NAME=chaos-ws.local.canaltp.fr
     command: /bin/bash /var/www/Chaos/docker/honcho_launcher.sh
     volumes:


### PR DESCRIPTION
# Description

This PR adds the ability to build docker images via Chaos embedded, this image is customizable using environment variables:

* SQLALCHEMY_DATABASE_URI
* DEBUG
* NAVITIA_URL
* RABBITMQ_ENABLED
* RABBITMQ_CONNECTION_STRING
* RABBITMQ_EXCHANGE
* PROFILING_ENABLED

## Pull Request type

This is a new feature

## How to test

Here are the following steps to test this pull request:

```
docker build -t chaos-ws .
docker run -d -e POSTGRES_USER=navitia -e POSTGRES_PASSWORD=navitia -e POSTGRES_DB=chaos --name chaos_db par-vm232.srv.canaltp.fr:5000/chaos-db
docker run -it --rm -e SQLALCHEMY_DATABASE_URI="postgresql://navitia:navitia@database/chaos" --link chaos_db:database -e RABBITMQ_ENABLED=0 chaos-ws sh -c "until nc -z database 5432; do echo -n '.' ; sleep 1 ; done ; python manage.py db upgrade"
docker run -d -e SQLALCHEMY_DATABASE_URI="postgresql://navitia:navitia@database/chaos" -e RABBITMQ_ENABLED=0 --link chaos_db:database --name chaos  chaos-ws
```
Chaos should be accessible on port 5000 of chaos container.

## Team reviewers

@CanalTP/transteam 