### PR TITLE
Make error message more explicit when severity couldn't be found

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -209,7 +209,7 @@ class Severity(TimestampMixin, db.Model):
             ).first()
 
         if severity is None:
-            raise exceptions.ObjectUnknown('The severty with id {} does not exist for this client.'.format(id))
+            raise exceptions.ObjectUnknown('The severty with id {} does not exist for this client'.format(id))
 
         return severity
 

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -209,7 +209,7 @@ class Severity(TimestampMixin, db.Model):
             ).first()
 
         if severity is None:
-            raise exceptions.ObjectUnknown('Unable to find the severty with id {} and client id {}'.format(id, client_id))
+            raise exceptions.ObjectUnknown('The severty with id {} does not exist for this client.'.format(id))
 
         return severity
 

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -37,7 +37,6 @@ from datetime import datetime
 from formats import publication_status_values
 from sqlalchemy import or_, and_, between
 from sqlalchemy.orm import aliased
-import logging
 
 
 # force the server to use UTC time for each connection

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -30,13 +30,14 @@
 # www.navitia.io
 
 import uuid
-from chaos import db, utils
+from chaos import db, utils, exceptions
 from utils import paginate, get_current_time
 from sqlalchemy.dialects.postgresql import UUID, BIT
 from datetime import datetime
 from formats import publication_status_values
 from sqlalchemy import or_, and_, between
 from sqlalchemy.orm import aliased
+import logging
 
 
 # force the server to use UTC time for each connection
@@ -202,12 +203,16 @@ class Severity(TimestampMixin, db.Model):
 
     @classmethod
     def get(cls, id, client_id):
-        return cls.query.filter_by(
-            id=id,
-            client_id=client_id,
-            is_visible=True
-        ).first_or_404()
+        severity = cls.query.filter_by(
+                id=id,
+                client_id=client_id,
+                is_visible=True
+            ).first()
 
+        if severity is None:
+            raise exceptions.ObjectUnknown('Unable to find the severty with id {} and client id {}'.format(id, client_id))
+
+        return severity
 
 class Category(TimestampMixin, db.Model):
     """

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -77,7 +77,12 @@ class Severity(flask_restful.Resource):
     @validate_id()
     def get(self, client, id=None):
         if id:
-            return marshal({'severity': models.Severity.get(id, client.id)}, one_severity_fields)
+            try:
+                severity = models.Severity.get(id, client.id)
+            except exceptions.ObjectUnknown, e:
+                return marshal({'error': {'message': utils.parse_error(e)}},
+                               error_fields), 404
+            return marshal({'severity': severity}, one_severity_fields)
         else:
             response = {'severities': models.Severity.all(client.id), 'meta': {}}
             return marshal(response, severities_fields)
@@ -111,7 +116,11 @@ class Severity(flask_restful.Resource):
     @validate_id(True)
     def put(self, client, id):
 
-        severity = models.Severity.get(id, client.id)
+        try:
+            severity = models.Severity.get(id, client.id)
+        except exceptions.ObjectUnknown, e:
+            return marshal({'error': {'message': utils.parse_error(e)}},
+                           error_fields), 404
         json = request.get_json(silent=True)
         logging.getLogger(__name__).debug('PUT severity: %s', json)
 
@@ -137,7 +146,11 @@ class Severity(flask_restful.Resource):
     @validate_id(True)
     def delete(self, client, id):
 
-        severity = models.Severity.get(id, client.id)
+        try:
+            severity = models.Severity.get(id, client.id)
+        except exceptions.ObjectUnknown, e:
+            return marshal({'error': {'message': utils.parse_error(e)}},
+                           error_fields), 404
         severity.is_visible = False
         db.session.commit()
         return None, 204

--- a/tests/features/deletion-severity.feature
+++ b/tests/features/deletion-severity.feature
@@ -120,3 +120,27 @@ Feature: Severity can be deleted
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "id invalid"
+
+    Scenario: Client could delete only his severity
+
+        Given I have the following clients in my database:
+        | client_code   | created_at          | updated_at          | id                                   |
+        | 7             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+        | 8             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following severities in my database:
+        | wording                | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+        | severity_for_client_7  | #123456 | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+        | severity_for_client_8  | #ffffff | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 6ffab229-3d48-4eea-aa2c-22f8680230b6 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "8"
+
+        #when client_8 trys to remove a severity created by client_7 an arror should be created
+        When I delete to "/severities/7ffab230-3d48-4eea-aa2c-22f8680230b6":
+        Then the status code should be "404"
+        And the header "Content-Type" should be "application/json"
+        And the field "error" should have a size of 1
+        And the field "error.message" should be "The severty with id 7ffab230-3d48-4eea-aa2c-22f8680230b6 does not exist for this client"
+
+        #client_8 could be able to remove severity created by himself
+        When I delete to "/severities/6ffab229-3d48-4eea-aa2c-22f8680230b6":
+        Then the status code should be "204"

--- a/tests/features/list-severity.feature
+++ b/tests/features/list-severity.feature
@@ -56,7 +56,6 @@ Feature: list severity
             And the field "severities.1.color" should be "#654321"
             And the field "severities.1.priority" should be null
 
-
         Scenario: only visible severities have to be return
             Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
@@ -148,3 +147,26 @@ Feature: list severity
             And the field "severities.1.color" should be "#654321"
             And the field "severities.1.priority" should be null
             And the field "severities.1.effect" should be "no_service"
+
+        Scenario: Severity could be retrieved by ID and for client
+            Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 7             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+            | 8             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            Given I have the following severities in my database:
+            | wording                | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | severity_for_client_7  | #123456 | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+            | severity_for_client_8  | #ffffff | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 6ffab229-3d48-4eea-aa2c-22f8680230b6 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+            I fill in header "X-Customer-Id" with "8"
+            When I get "/severities/5ffab229-3d48-4eea-aa2c-22f8680230b5"
+            Then the status code should be "404"
+            And the header "Content-Type" should be "application/json"
+            And the field "error" should have a size of 1
+            And the field "error.message" should be "The severty with id 5ffab229-3d48-4eea-aa2c-22f8680230b5 does not exist for this client"
+
+            #A severity created by client is visible for that client
+            When I get "/severities/6ffab229-3d48-4eea-aa2c-22f8680230b6"
+            Then the status code should be "200"
+            And the header "Content-Type" should be "application/json"
+            And the field "severity.wording" should be "severity_for_client_8"

--- a/tests/features/update-severity.feature
+++ b/tests/features/update-severity.feature
@@ -191,3 +191,35 @@ Feature: update severity
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "id invalid"
+
+    Scenario: Client could update only his severity
+
+        Given I have the following clients in my database:
+        | client_code   | created_at          | updated_at          | id                                   |
+        | 7             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+        | 8             | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following severities in my database:
+        | wording                | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+        | severity_for_client_7  | #123456 | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 5ffab229-3d48-4eea-aa2c-22f8680230b5 |
+        | severity_for_client_8  | #ffffff | 2017-01-30T00:00:00 | 2017-01-30T00:00:00 | True       | 6ffab229-3d48-4eea-aa2c-22f8680230b6 | 6ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "8"
+
+        #trying update severity of client_8 by client_7 should raise an arror
+        When I put to "/severities/7ffab230-3d48-4eea-aa2c-22f8680230b6" with:
+        """
+        { "color": "#FFFFFF", "effect": "no_service", "priority": 1, "wording": "Blocking", "wordings": [ { "key": "short", "value": "short" }, { "key": "medium", "value": "medium" }, { "key": "long", "value": "long" } ]}
+        """
+        Then the status code should be "404"
+        And the header "Content-Type" should be "application/json"
+        And the field "error" should have a size of 1
+        And the field "error.message" should be "The severty with id 7ffab230-3d48-4eea-aa2c-22f8680230b6 does not exist for this client"
+
+        #trying update severity of client_8 by client_8 should be fine
+        When I put to "/severities/6ffab229-3d48-4eea-aa2c-22f8680230b6" with:
+        """
+        { "color": "#111111", "effect": "no_service", "priority": 1, "wording": "Blocking", "wordings": [ { "key": "short", "value": "short" }, { "key": "medium", "value": "medium" }, { "key": "long", "value": "long" } ]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "severity.color" should be "#111111"


### PR DESCRIPTION
# Description

During creation of an disruption, if impact contains wrong severity ID
application throws an NotFound exception and error message is ambiguous.
This PR fix that issue : Explicit message with used severity and Client
IDs would be displayed.

## Issue (optional)

Issue link: rzo-280

## Pull Request type (optional)

This is a bug new feature

## How to test

Here are the following steps to test this pull request:

- make a HTTP POST request with contains impact with wrong severity ID
- Response code should be 404 with body 

```
{
    "error": {
        "message": "Unable to find the severty with id "xyz" and client id xzz"
    }
}
```