### PR TITLE
forward raw authorization header

### DIFF
--- a/chaos/navitia.py
+++ b/chaos/navitia.py
@@ -67,7 +67,7 @@ class Navitia(object):
     def navitia_caller(self, query):
 
         try:
-            return requests.get(query, auth=(self.token, None), timeout=self.timeout)
+            return requests.get(query, headers={"Authorization": self.token}, timeout=self.timeout)
         except (requests.exceptions.RequestException):
             logging.getLogger(__name__).exception('call to navitia failed')
             # currently we reraise the previous exceptions

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -214,12 +214,13 @@ class Disruptions(flask_restful.Resource):
     def get_error_response_and_log(self, method, exception, status_code):
         response_content = marshal({'error': {'message': '{}'.format(exception.message)}}, error_fields)
         logging.getLogger(__name__).debug(
-            "\nError REQUEST %s disruption: [X-Customer-Id:%s;X-Coverage:%s;X-Contributors:%s] with payload \n%s" +
+            "\nError REQUEST %s disruption: [X-Customer-Id:%s;X-Coverage:%s;X-Contributors:%s;Authorization:%s] with payload \n%s" +
             "\ngot RESPONSE with status %d:\n%s",
             method,
             request.headers.get('X-Customer-Id'),
             request.headers.get('X-Coverage'),
             request.headers.get('X-Contributors'),
+            request.headers.get('Authorization'),
             json.dumps(request.get_json(silent=True)),
             status_code,
             json.dumps(response_content)


### PR DESCRIPTION
# Description

This PR fixes a bug when filling Authorization header with other value than raw Navitia token (i.e. Basic MjdY5ODE3YWEtOWExMy00MDZlLThkOTEtMDgwM2NiNWIyOGY0Og==). The Authorization value was forwarded as the HTTP user and not the Authorization header value.

## Issue (optional)

Issue link:

## Pull Request type (optional)

This is a bug fix

## How to test

POST a disruption with 
```
Authorization: <your_raw_token>
```

AND 
```
Authorization: Basic base64encode(<your_raw_token>)
```

Result and Navitia request should be the same