### PR TITLE
Use navitia/python image to avoid uwsgi compilation failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM alpine:edge
+FROM navitia/python
 
 WORKDIR /usr/src/app
 COPY . /usr/src/app
-
-RUN echo http://dl-3.alpinelinux.org/alpine/edge/testing  >> /etc/apk/repositories
 
 RUN apk --update --no-cache add \
         g++ \
@@ -16,9 +14,7 @@ RUN apk --update --no-cache add \
         musl-dev \
         git \
         postgresql-dev && \
-    pip install -U pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir uwsgi && \
     apk del \
         g++ \
         build-base \


### PR DESCRIPTION
# Description

This PR fixes the random build failure of uwsgi (always happens in Jenkins build job).
For that, we use the navitia/python base image where uwsgi is already compiled

## Pull Request type (optional)

This is a bug fix

## How to test

Here are the following steps to test this pull request:

- docker build .
- This command must never fail

## Team reviewers (optional)

@CanalTP/transteam 
