### PR TITLE
Feature rzo 462 wording for cause

### DIFF
--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -89,21 +89,27 @@ def manage_pt_object_without_line_section(navitia, db_objects, json_attribute, j
             db_objects.remove(pt_object_db[ptobject_uri])
 
 
-def manage_wordings(db_object, json_wordings, json_default_wording=None):
+def manage_wordings(db_object, json):
     db_object.delete_wordings()
-    for json_wording in json_wordings:
+
+    #handle wordings
+    wordings = json['wordings']
+
+    for json_wording in wordings:
         db_wording = models.Wording()
         key = json_wording["key"].strip()
         if key == '':
-            raise exceptions.InvalidJson('Json invalid: key is empty, you give : {}'.format(json_wordings))
+            raise exceptions.InvalidJson('Json invalid: key is empty, you give : {}'.format(wordings))
+
         db_wording.key = json_wording["key"]
         db_wording.value = json_wording["value"]
         db_object.wordings.append(db_wording)
-    if json_default_wording:
-        db_object.wording = json_default_wording
-    else:
-        db_object.wording = db_object.wordings[0].value
 
+    #handle wording
+    wording = db_object.wordings[0].value
+    if 'wording' in json:
+        wording = json['wording']
+    db_object.wording = wording
 
 def manage_tags(disruption, json):
     tags_db = dict((tag.id, tag) for tag in disruption.tags)
@@ -185,7 +191,9 @@ def fill_and_add_line_section(navitia, impact_id, all_objects, pt_object_json):
     #"meta":[{"key":"direction", "value": "1234"}, {"key":"direction", "value": "5678"}]
     if 'metas' in line_section_json:
         try:
-            manage_wordings(line_section, line_section_json['metas'])
+            metas = {}
+            metas['wordings'] = line_section_json['metas']
+            manage_wordings(line_section, metas)
         except exceptions.InvalidJson:
             raise
 

--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -99,10 +99,10 @@ def manage_wordings(db_object, json_wordings, json_default_wording=None):
         db_wording.key = json_wording["key"]
         db_wording.value = json_wording["value"]
         db_object.wordings.append(db_wording)
-    if json_default_wording is None:
-        db_object.wording = db_object.wordings[0].value
-    else:
+    if json_default_wording:
         db_object.wording = json_default_wording
+    else:
+        db_object.wording = db_object.wordings[0].value
 
 
 def manage_tags(disruption, json):

--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -89,7 +89,7 @@ def manage_pt_object_without_line_section(navitia, db_objects, json_attribute, j
             db_objects.remove(pt_object_db[ptobject_uri])
 
 
-def manage_wordings(db_object, json_wordings):
+def manage_wordings(db_object, json_wordings, json_default_wording=None):
     db_object.delete_wordings()
     for json_wording in json_wordings:
         db_wording = models.Wording()
@@ -99,7 +99,10 @@ def manage_wordings(db_object, json_wordings):
         db_wording.key = json_wording["key"]
         db_wording.value = json_wording["value"]
         db_object.wordings.append(db_wording)
-    db_object.wording = db_object.wordings[0].value
+    if json_default_wording is None:
+        db_object.wording = db_object.wordings[0].value
+    else:
+        db_object.wording = json_default_wording
 
 
 def manage_tags(disruption, json):

--- a/chaos/fields.py
+++ b/chaos/fields.py
@@ -157,9 +157,8 @@ class ComputeDisruptionStatus(fields.Raw):
 
 class FieldCause(fields.Raw):
     def output(self, key, obj):
-        disruption = obj.disruption
-        if hasattr(obj.disruption, 'cause'):
-            return disruption.cause.wording
+        if hasattr(obj.disruption, 'cause') and hasattr(obj.disruption.cause, 'wording'):
+            return obj.disruption.cause.wording
         return None
 
 

--- a/chaos/fields.py
+++ b/chaos/fields.py
@@ -159,9 +159,7 @@ class FieldCause(fields.Raw):
     def output(self, key, obj):
         disruption = obj.disruption
         if hasattr(obj.disruption, 'cause') and hasattr(obj.disruption.cause, 'wordings'):
-            for wording in disruption.cause.wordings:
-                if wording.key == 'external_medium':
-                    return wording.value
+            return disruption.cause.wording
         return None
 
 

--- a/chaos/fields.py
+++ b/chaos/fields.py
@@ -158,7 +158,7 @@ class ComputeDisruptionStatus(fields.Raw):
 class FieldCause(fields.Raw):
     def output(self, key, obj):
         disruption = obj.disruption
-        if hasattr(obj.disruption, 'cause') and hasattr(obj.disruption.cause, 'wordings'):
+        if hasattr(obj.disruption, 'cause'):
             return disruption.cause.wording
         return None
 

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -468,6 +468,8 @@ class Cause(flask_restful.Resource):
                            error_fields), 400
 
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
+        if 'wording' not in json:
+            json["wording"] = None
         try:
             db_helper.manage_wordings(cause, json["wordings"], json["wording"])
         except exceptions.InvalidJson, e:

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -440,6 +440,8 @@ class Cause(flask_restful.Resource):
         cause = models.Cause()
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
         cause.client = client
+        if 'wording' not in json:
+            json["wording"] = None
         try:
             db_helper.manage_wordings(cause, json["wordings"], json["wording"])
         except exceptions.InvalidJson, e:

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -441,7 +441,7 @@ class Cause(flask_restful.Resource):
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
         cause.client = client
         try:
-            db_helper.manage_wordings(cause, json["wordings"])
+            db_helper.manage_wordings(cause, json["wordings"], json["wording"])
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400
@@ -467,7 +467,7 @@ class Cause(flask_restful.Resource):
 
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
         try:
-            db_helper.manage_wordings(cause, json["wordings"])
+            db_helper.manage_wordings(cause, json["wordings"], json["wording"])
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -103,7 +103,7 @@ class Severity(flask_restful.Resource):
         mapper.fill_from_json(severity, json, mapper.severity_mapping)
         severity.client = client
         try:
-            db_helper.manage_wordings(severity, json["wordings"])
+            db_helper.manage_wordings(severity, json)
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400
@@ -134,7 +134,7 @@ class Severity(flask_restful.Resource):
 
         mapper.fill_from_json(severity, json, mapper.severity_mapping)
         try:
-            db_helper.manage_wordings(severity, json["wordings"])
+            db_helper.manage_wordings(severity, json)
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400
@@ -440,10 +440,8 @@ class Cause(flask_restful.Resource):
         cause = models.Cause()
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
         cause.client = client
-        if 'wording' not in json:
-            json["wording"] = None
         try:
-            db_helper.manage_wordings(cause, json["wordings"], json["wording"])
+            db_helper.manage_wordings(cause, json)
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400
@@ -468,10 +466,8 @@ class Cause(flask_restful.Resource):
                            error_fields), 400
 
         mapper.fill_from_json(cause, json, mapper.cause_mapping)
-        if 'wording' not in json:
-            json["wording"] = None
         try:
-            db_helper.manage_wordings(cause, json["wordings"], json["wording"])
+            db_helper.manage_wordings(cause, json)
         except exceptions.InvalidJson, e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 400

--- a/tests/features/create-cause.feature
+++ b/tests/features/create-cause.feature
@@ -83,6 +83,7 @@ Feature: Create cause
         """
         Then the status code should be "201"
         And the header "Content-Type" should be "application/json"
+        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "bb"
 
     Scenario: Cause with empty key
        Given I have the following clients in my database:
@@ -115,3 +116,4 @@ Feature: Create cause
         Then the status code should be "201"
         And the header "Content-Type" should be "application/json"
         And the field "cause.wordings" should have a size of 3
+        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "mm"

--- a/tests/features/create-cause.feature
+++ b/tests/features/create-cause.feature
@@ -83,7 +83,6 @@ Feature: Create cause
         """
         Then the status code should be "201"
         And the header "Content-Type" should be "application/json"
-        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "bb"
 
     Scenario: Cause with empty key
        Given I have the following clients in my database:
@@ -116,4 +115,3 @@ Feature: Create cause
         Then the status code should be "201"
         And the header "Content-Type" should be "application/json"
         And the field "cause.wordings" should have a size of 3
-        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "mm"

--- a/tests/features/create-cause.feature
+++ b/tests/features/create-cause.feature
@@ -98,7 +98,7 @@ Feature: Create cause
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "Json invalid: key is empty, you give : [{u'value': u'bb', u'key': u'  '}]"
 
-    Scenario: creation of cause with default wordin
+    Scenario: creation of cause with default wording
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |

--- a/tests/features/create-cause.feature
+++ b/tests/features/create-cause.feature
@@ -97,3 +97,21 @@ Feature: Create cause
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "Json invalid: key is empty, you give : [{u'value': u'bb', u'key': u'  '}]"
+
+    Scenario: creation of cause with default wordin
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following categories in my database:
+            | name      | note  | created_at          | updated_at          | id                                   | client_id                            |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        When I post to "/causes" with:
+        """
+        {"wording": "mm", "wordings": [{"key": "aa", "value": "bb"}, {"key": "dd", "value": "cc"}, {"key": "pp", "value": "mm"}], "category":{"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"}}
+        """
+        Then the status code should be "201"
+        And the header "Content-Type" should be "application/json"
+        And the field "cause.wordings" should have a size of 3

--- a/tests/features/update-cause.feature
+++ b/tests/features/update-cause.feature
@@ -102,6 +102,7 @@ Feature: update cause
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "cause.wordings" should have a size of 2
+        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "bb"
 
     Scenario: I can update a cause with a default wording
         Given I have the following clients in my database:
@@ -120,7 +121,7 @@ Feature: update cause
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "cause.wordings" should have a size of 2
-
+        And in the database for the cause "7ffab230-3d48-4eea-aa2c-22f8680230b6" the field "wording" should be "cc"
 
     Scenario: I can't update a invisible cause
         Given I have the following clients in my database:

--- a/tests/features/update-cause.feature
+++ b/tests/features/update-cause.feature
@@ -103,6 +103,24 @@ Feature: update cause
         And the header "Content-Type" should be "application/json"
         And the field "cause.wordings" should have a size of 2
 
+    Scenario: I can update a cause with a default wording
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | strike    | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | False      | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        I fill in header "X-Customer-Id" with "5"
+        When I put to "/causes/7ffab230-3d48-4eea-aa2c-22f8680230b6" with:
+        """
+        {"wording": "cc", "wordings": [{"key": "aa", "value": "bb"}, {"key": "dd", "value": "cc"}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "cause.wordings" should have a size of 2
+
 
     Scenario: I can't update a invisible cause
         Given I have the following clients in my database:

--- a/tests/fields_test.py
+++ b/tests/fields_test.py
@@ -310,13 +310,9 @@ def test_field_cause():
     obj = Obj()
     obj.disruption = models.Disruption()
     cause = models.Cause()
-    wording = models.Wording()
-    wording.key = 'external_medium'
-    wording.value = 'external medium'
-    cause.wordings.append(wording)
     obj.disruption.cause = cause
     class_field_cause = fields.FieldCause(Obj())
-    eq_(class_field_cause.output(None, obj), 'external medium')
+    eq_(class_field_cause.output(None, obj), cause.wording)
 
 
 def test_field_cause_none():
@@ -325,7 +321,7 @@ def test_field_cause_none():
     cause = models.Cause()
     wording = models.Wording()
     wording.key = 'external_long'
-    wording.value = 'external medium'
+    wording.value = 'message'
     cause.wordings.append(wording)
     obj.disruption.cause = cause
     class_field_cause = fields.FieldCause(Obj())

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -4,7 +4,7 @@ import os
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_test'
+SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
 

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -4,7 +4,7 @@ import os
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'
+SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_test'
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
 


### PR DESCRIPTION
# Description

This PR adds wording management in PUT/POST cause if configuration in Traffic report exists (param 'wording' see https://github.com/CanalTP/RealTimeBundle/pull/366 )

## Issue (optional)

Issue link: RZO-462

## How to test
POST or PUT a cause to chaos with or without 'wording' into cause json
then check which value  arrives into db table /cause/wording