### PR TITLE
fix: typo when an error occurs after a post request in disruptions api

### DIFF
--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -300,10 +300,10 @@ class Disruptions(flask_restful.Resource):
         except exceptions.NavitiaError, e:
             db.session.delete(disruption)
             db.session.commit()
-            return marshal({'error': {'message': '{}'.format(e.message)}}, fields.error_fields), 503
+            return marshal({'error': {'message': '{}'.format(e.message)}}, error_fields), 503
         except Exception, e:
             db.session.rollback()
-            return marshal({'error': {'message': '{}'.format(e.message)}}, fields.error_fields), 500
+            return marshal({'error': {'message': '{}'.format(e.message)}}, error_fields), 500
 
 
     @validate_navitia()


### PR DESCRIPTION
# Description

This PR fixes an error when an error occurs ^^ after a POST request on /disruptions.
This is just a mistake on error_fields when marshaling response.

I want to mention the fact that if the postgresql database speaks UTF-8 french, then CHAOS explodes on all the psycopg exceptions. (because of encoding) But I don't know who is to be blamed on this.

Thanks.
