### PR TITLE
Refacto dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
         libpq5 \
         libprotobuf9 \
         libpython2.7 \
+        netcat \
         && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,30 @@
-FROM navitia/python
+FROM debian:jessie
 
-WORKDIR /usr/src/app
-COPY . /usr/src/app
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -yq install \
+        wget \
+        python-pip \
+        libpq5 \
+        libprotobuf9 \
+        libpython2.7 \
+        && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apk --update --no-cache add \
-        g++ \
-        build-base \
-        python-dev \
-        py2-pip \
-        zlib-dev \
-        linux-headers \
-        musl \
-        musl-dev \
-        git \
-        postgresql-dev && \
-    pip install --no-cache-dir -r requirements.txt && \
-    apk del \
-        g++ \
-        build-base \
-        python-dev \
-        zlib-dev \
-        linux-headers \
-        musl \
-        musl-dev
+COPY . /srv/chaos
+WORKDIR /srv/chaos
+
+RUN set -xe && \
+    buildDeps="libpq-dev python-dev protobuf-compiler git" && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -yq install $buildDeps && \
+    pip install uwsgi && \
+    pip install -r requirements.txt && \
+    python setup.py build_pbf && cd .. && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000
-
-WORKDIR /usr/src/app/
 
 ENV CHAOS_CONFIG_FILE=default_settings.py
 ENV PYTHONPATH=.
 CMD ["uwsgi", "--mount", "/=chaos:app", "--http", "0.0.0.0:5000"]
-

--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -10,19 +10,23 @@ NAVITIA_URL = str(os.getenv('NAVITIA_URL', 'http://navitia2-ws.ctp.dev.canaltp.f
 
 # rabbitmq connections string: http://kombu.readthedocs.org/en/latest/userguide/connections.html#urls
 RABBITMQ_CONNECTION_STRING = str(os.getenv('RABBITMQ_CONNECTION_STRING', 'pyamqp://guest:guest@localhost:5672//?heartbeat=60'))
-#Cache configuration, see https://pythonhosted.org/Flask-Cache/ for more information
+
+# Cache configuration, see https://pythonhosted.org/Flask-Cache/ for more information
+cache_type = str(os.getenv('CACHE_TYPE', 'simple'))
 CACHE_CONFIGURATION = {
-    'CACHE_TYPE': 'redis',
-    'CACHE_REDIS_HOST': 'localhost',
-    'CACHE_REDIS_PORT' : 6379,
-    'CACHE_REDIS_PASSWORD' : None,
-    'CACHE_REDIS_DB': 0,
-    'CACHE_DEFAULT_TIMEOUT' : 86400, #in seconds
-    'NAVITIA_CACHE_TIMEOUT' : 86400, #in seconds
-    'CACHE_KEY_PREFIX': 'Chaos'
+    'CACHE_TYPE': cache_type,
+    'CACHE_DEFAULT_TIMEOUT': 86400,  # in seconds
+    'NAVITIA_CACHE_TIMEOUT': 86400,  # in seconds
 }
 
-# amqp exhange used for sending disruptions
+if cache_type == 'redis':
+    CACHE_CONFIGURATION['CACHE_REDIS_HOST'] = str(os.getenv('CACHE_REDIS_HOST', 'localhost'))
+    CACHE_CONFIGURATION['CACHE_REDIS_PORT'] = os.getenv('CACHE_REDIS_PORT', 6379)
+    CACHE_CONFIGURATION['CACHE_REDIS_PASSWORD'] = os.getenv('CACHE_REDIS_PASSWORD', None)
+    CACHE_CONFIGURATION['CACHE_REDIS_DB'] = os.getenv('CACHE_REDIS_DB', 0)
+    CACHE_CONFIGURATION['CACHE_KEY_PREFIX'] = 'Chaos'
+
+# amqp exchange used for sending disruptions
 EXCHANGE = str(os.getenv('RABBITMQ_EXCHANGE', 'navitia'))
 
 ENABLE_RABBITMQ = (os.getenv('RABBITMQ_ENABLED', 1) == 1)


### PR DESCRIPTION
# Description

This PR fixes the dockerfile to use protobuf 2.6 and updates the configuration file to allow overriding cache config by environment variables 

## How to test

Here are the following steps to test this pull request:

- Build the image
- You should be able to launch TR tests without a redis instance


## Team reviewers (optional)

BOTeam
