### PR TITLE
Use Disruption rather than impact for traffic_reports

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -752,14 +752,6 @@ class Impact(TimestampMixin, db.Model):
         query = query.union_all(query_line_section).filter(and_(start_filter, end_filter)).order_by("application_periods_1.start_date")
         return query.all()
 
-    @classmethod
-    def traffic_report_filter(cls, contributor_id):
-        query = cls.query.filter(cls.status == 'published')
-        query = query.join(Disruption)
-        query = query.filter(Disruption.contributor_id == contributor_id)
-        query = query.filter(between(get_current_time(), Disruption.start_publication_date, Disruption.end_publication_date))
-        return query.all()
-
 
 associate_line_section_route_object = db.Table(
     'associate_line_section_route_object',

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -562,6 +562,14 @@ class Disruption(TimestampMixin, db.Model):
         if self.start_publication_date > current_time:
             return "coming"
 
+    @classmethod
+    def traffic_report_filter(cls, contributor_id):
+        query = cls.query.filter(cls.status == 'published')
+        query = query.filter(cls.contributor_id == contributor_id)
+        query = query.filter(
+            between(get_current_time(), cls.start_publication_date, cls.end_publication_date))
+        return query.all()
+
 
 associate_impact_pt_object = db.Table(
     'associate_impact_pt_object',

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -954,8 +954,8 @@ class TrafficReport(flask_restful.Resource):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
         g.current_time = args['current_time']
-        impacts = models.Impact.traffic_report_filter(contributor.id)
-        result = utils.get_traffic_report_objects(impacts, self.navitia)
+        disruptions = models.Disruption.traffic_report_filter(contributor.id)
+        result = utils.get_traffic_report_objects(disruptions, self.navitia)
         return marshal(
             {
                 'traffic_reports': [value for key, value in result["traffic_report"].items()],

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -567,7 +567,7 @@ def create_line_section(navitia_object, pt_object):
     return line_section
 
 
-def get_traffic_report_objects(impacts, navitia):
+def get_traffic_report_objects(disruptions, navitia):
     """
     :param impacts: Sequence of impact (Database object)
     :return: dict
@@ -601,16 +601,17 @@ def get_traffic_report_objects(impacts, navitia):
     }
 
     result = {'traffic_report': {}, 'impacts_used': []}
-    for impact in impacts:
-        for pt_object in impact.objects:
-            if pt_object.type == 'network':
-                manage_network(result, impact, pt_object, navitia)
-            else:
-                if pt_object.type not in collections:
-                    logging.getLogger(__name__).debug(
-                        'PtObject ignored: {type} [{uri}], not in collections {col}'.
-                        format(type=pt_object.type, uri=pt_object.uri, col=collections)
-                    )
-                    continue
-                manage_other_object(result, impact, pt_object, navitia, collections[pt_object.type])
+    for disruption in disruptions:
+        for impact in disruption.impacts:
+            for pt_object in impact.objects:
+                if pt_object.type == 'network':
+                    manage_network(result, impact, pt_object, navitia)
+                else:
+                    if pt_object.type not in collections:
+                        logging.getLogger(__name__).debug(
+                            'PtObject ignored: {type} [{uri}], not in collections {col}'.
+                            format(type=pt_object.type, uri=pt_object.uri, col=collections)
+                        )
+                        continue
+                    manage_other_object(result, impact, pt_object, navitia, collections[pt_object.type])
     return result

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -603,15 +603,17 @@ def get_traffic_report_objects(disruptions, navitia):
     result = {'traffic_report': {}, 'impacts_used': []}
     for disruption in disruptions:
         for impact in disruption.impacts:
-            for pt_object in impact.objects:
-                if pt_object.type == 'network':
-                    manage_network(result, impact, pt_object, navitia)
-                else:
-                    if pt_object.type not in collections:
-                        logging.getLogger(__name__).debug(
-                            'PtObject ignored: {type} [{uri}], not in collections {col}'.
-                            format(type=pt_object.type, uri=pt_object.uri, col=collections)
-                        )
-                        continue
-                    manage_other_object(result, impact, pt_object, navitia, collections[pt_object.type])
+            if impact.status == 'published':
+                for pt_object in impact.objects:
+                    if pt_object.type == 'network':
+                        manage_network(result, impact, pt_object, navitia)
+                    else:
+                        if pt_object.type not in collections:
+                            logging.getLogger(__name__).debug(
+                                'PtObject ignored: {type} [{uri}], not in collections {col}'.
+                                format(type=pt_object.type, uri=pt_object.uri, col=collections)
+                            )
+                            continue
+                        manage_other_object(result, impact, pt_object, navitia, collections[pt_object.type])
+
     return result

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1335,3 +1335,74 @@ Feature: traffic report api
         And the field "traffic_reports.0.stop_areas" should have a size of 2
         And the field "traffic_reports.0.stop_points" should have a size of 2
 
+    Scenario: One network in an impact archived, one line, 2 stop_areas and 2 stop_points
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date|end_publication_date|
+            | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived  | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type          | uri                                       | created_at          | updated_at          | id                                         |
+            | network       | network:JDR:2                             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b1       |
+            | line          | line:JDR:TGV                              | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b2       |
+            | stop_area     | stop_area:JDR:SA:GareMontparnasse         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b3       |
+            | stop_area     | stop_area:JDR:SA:LeMans                   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b4       |
+            | stop_point    | stop_point:JDR:SP:Nantes-TGV              | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b5       |
+            | stop_point    | stop_point:JDR:SP:GareMontparnasse-TGV    | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b1       | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b2       | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b3       | 7ffab232-3d47-4eea-aa2c-22f8680230b3 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b4       | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b5       | 7ffab232-3d47-4eea-aa2c-22f8680230b5 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab232-3d47-4eea-aa2c-22f8680230b3 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "a9fe6a75-e326-4eb1-9bf5-95727dd1b239"
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
+        Then the status code should be "200"
+        And the field "disruptions" should have a size of 5
+        And the field "traffic_reports" should have a size of 1
+        And the field "traffic_reports.0.network.id" should be "network:JDR:2"
+        And the field "traffic_reports.0.network.name" should be "SNCF"
+        And the field "traffic_reports.0.network.links" should not exist
+        And the field "traffic_reports.0.lines" should have a size of 1
+        And the field "traffic_reports.0.lines.0.id" should be "line:JDR:TGV"
+        And the field "traffic_reports.0.lines.0.links" should have a size of 1
+        And the field "traffic_reports.0.lines.0.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b2"
+        And the field "traffic_reports.0.stop_areas" should have a size of 2
+        And the field "traffic_reports.0.stop_points" should have a size of 2

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1392,7 +1392,7 @@ Feature: traffic report api
 
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
-        I fill in header "Authorization" with "a9fe6a75-e326-4eb1-9bf5-95727dd1b239"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
         Then the status code should be "200"
         And the field "disruptions" should have a size of 5

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -775,19 +775,13 @@ Feature: traffic report api
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2
         And the field "traffic_reports" should have a size of 1
-        And the field "disruptions.0.status" should be "active"
-        And the field "disruptions.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.0.disruption_id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.1.status" should be "active"
-        And the field "disruptions.1.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b7"
-        And the field "disruptions.1.disruption_id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b7"
+        And the field "disruptions" should contain all of "{"status": "active", "id": "7ffab232-3d47-4eea-aa2c-22f8680230b6", "disruption_id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"}"
+        And the field "disruptions" should contain all of "{"status": "active", "id": "7ffab232-3d47-4eea-aa2c-22f8680230b7", "disruption_id": "7ffab230-3d48-4eea-aa2c-22f8680230b7"}"
         And the field "traffic_reports.0.network.id" should be "network:JDR:1"
         And the field "traffic_reports.0.network.name" should be "RATP"
         And the field "traffic_reports.0.network.links" should have a size of 2
-        And the field "traffic_reports.0.network.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b6"
-        And the field "traffic_reports.0.network.links.0.rel" should be "disruptions"
-        And the field "traffic_reports.0.network.links.1.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b7"
-        And the field "traffic_reports.0.network.links.1.rel" should be "disruptions"
+        And the field "traffic_reports.0.network.links" should contain all of "{"id": "7ffab232-3d47-4eea-aa2c-22f8680230b6", "rel": "disruptions"}"
+        And the field "traffic_reports.0.network.links" should contain all of "{"id": "7ffab232-3d47-4eea-aa2c-22f8680230b7", "rel": "disruptions"}"
 
 
         Scenario: Impact on 2 networks, current_time between start publication period and end application period

--- a/tests/traffic_reports_test.py
+++ b/tests/traffic_reports_test.py
@@ -51,6 +51,7 @@ def test_get_traffic_report_with_network():
     network.uri = 'uri1'
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
     impact.objects.append(network)
     disruption.impacts.append(impact)
     result = {
@@ -110,6 +111,7 @@ def test_get_traffic_report_with_impact_on_lines():
     navitia.get_pt_object = get_pt_object
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
 
     line = chaos.models.PTobject()
     line.type = 'line'
@@ -147,6 +149,7 @@ def test_get_traffic_report_with_impact_on_networks():
     navitia.get_pt_object = get_pt_object
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
 
     line = chaos.models.PTobject()
     line.type = 'network'
@@ -185,6 +188,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_one_network():
     navitia.get_pt_object = get_pt_object
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
 
     line = chaos.models.PTobject()
     line.type = 'stop_area'
@@ -210,6 +214,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
     navitia.get_pt_object = get_pt_object
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
 
     line = chaos.models.PTobject()
     line.type = 'stop_area'
@@ -245,6 +250,7 @@ def test_get_traffic_report_with_2_impact_on_stop_area():
 
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
     stop_area = chaos.models.PTobject()
     stop_area.type = 'stop_area'
     stop_area.uri = 'stop_area:uri1'
@@ -255,6 +261,7 @@ def test_get_traffic_report_with_2_impact_on_stop_area():
 
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
     stop_area = chaos.models.PTobject()
     stop_area.type = 'stop_area'
     stop_area.uri = 'stop_area:uri1'
@@ -281,6 +288,7 @@ def test_get_traffic_report_with_impact_on_line_sections():
     navitia.get_pt_object = get_pt_object
     disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
+    impact.status = 'published'
 
     #LineSection
     ptobject = chaos.models.PTobject()

--- a/tests/traffic_reports_test.py
+++ b/tests/traffic_reports_test.py
@@ -14,8 +14,8 @@ def test_get_traffic_report_objects():
 
 
 def test_get_traffic_report_without_objects():
-    impact = chaos.models.Impact()
-    dd = get_traffic_report_objects([impact], Obj())
+    disruption = chaos.models.Disruption()
+    dd = get_traffic_report_objects([disruption], Obj())
     eq_(len(dd["traffic_report"].items()), 0)
 
 
@@ -49,8 +49,10 @@ def test_get_traffic_report_with_network():
     network = chaos.models.PTobject()
     network.type = 'network'
     network.uri = 'uri1'
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
     impact.objects.append(network)
+    disruption.impacts.append(impact)
     result = {
         "uri1": {
             "network": {
@@ -60,7 +62,7 @@ def test_get_traffic_report_with_network():
             }
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -106,6 +108,7 @@ def get_pt_object(uri, object_type, pt_objects=None):
 def test_get_traffic_report_with_impact_on_lines():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
 
     line = chaos.models.PTobject()
@@ -117,6 +120,7 @@ def test_get_traffic_report_with_impact_on_lines():
     line.type = 'line'
     line.uri = 'line:uri2'
     impact.objects.append(line)
+    disruption.impacts.append(impact)
 
     result = {
         "network:uri1": {
@@ -134,13 +138,14 @@ def test_get_traffic_report_with_impact_on_lines():
             "lines": [{'id': 'line:uri2', 'name': 'line 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
 def test_get_traffic_report_with_impact_on_networks():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
 
     line = chaos.models.PTobject()
@@ -152,6 +157,7 @@ def test_get_traffic_report_with_impact_on_networks():
     line.type = 'network'
     line.uri = 'network:uri2'
     impact.objects.append(line)
+    disruption.impacts.append(impact)
 
     result = {
         "network:uri1": {
@@ -169,7 +175,7 @@ def test_get_traffic_report_with_impact_on_networks():
             }
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
 
     eq_(cmp(dd["traffic_report"], result), 0)
 
@@ -177,12 +183,14 @@ def test_get_traffic_report_with_impact_on_networks():
 def test_get_traffic_report_with_impact_on_stop_areas_one_network():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
 
     line = chaos.models.PTobject()
     line.type = 'stop_area'
     line.uri = 'stop_area:uri1'
     impact.objects.append(line)
+    disruption.impacts.append(impact)
 
     result = {
         "network:uri3": {
@@ -193,19 +201,21 @@ def test_get_traffic_report_with_impact_on_stop_areas_one_network():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
 def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
 
     line = chaos.models.PTobject()
     line.type = 'stop_area'
     line.uri = 'stop_area:uri2'
     impact.objects.append(line)
+    disruption.impacts.append(impact)
 
     result = {
         "network:uri4": {
@@ -223,27 +233,34 @@ def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
             "stop_areas": [{'id': 'stop_area:uri2', 'name': 'stop area 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
 def test_get_traffic_report_with_2_impact_on_stop_area():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruptions = []
     impacts = []
 
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
     stop_area = chaos.models.PTobject()
     stop_area.type = 'stop_area'
     stop_area.uri = 'stop_area:uri1'
     impact.objects.append(stop_area)
-
+    disruption.impacts.append(impact)
+    disruptions.append(disruption)
     impacts.append(impact)
+
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
     stop_area = chaos.models.PTobject()
     stop_area.type = 'stop_area'
     stop_area.uri = 'stop_area:uri1'
     impact.objects.append(stop_area)
+    disruption.impacts.append(impact)
+    disruptions.append(disruption)
     impacts.append(impact)
 
     result = {
@@ -255,13 +272,14 @@ def test_get_traffic_report_with_2_impact_on_stop_area():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": impacts}]
         }
     }
-    dd = get_traffic_report_objects(impacts, navitia)
+    dd = get_traffic_report_objects(disruptions, navitia)
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
 def test_get_traffic_report_with_impact_on_line_sections():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
     impact = chaos.models.Impact()
 
     #LineSection
@@ -284,6 +302,7 @@ def test_get_traffic_report_with_impact_on_line_sections():
     ptobject.line_section.end_point.type = 'stop_area'
 
     impact.objects.append(ptobject)
+    disruption.impacts.append(impact)
 
     result = {
         "network:uri1": {
@@ -319,5 +338,5 @@ def test_get_traffic_report_with_impact_on_line_sections():
             ]
         }
     }
-    dd = get_traffic_report_objects([impact], navitia)
+    dd = get_traffic_report_objects([disruption], navitia)
     eq_(cmp(dd["traffic_report"], result), 0)


### PR DESCRIPTION
# Description

This PR addresses performance issues on /traffic_reports API since latest optimizations

## Pull Request type (optional)

This is a performance optimization

## How to test

Here are the following steps to test this pull request:

- /traffic_reports should act the same way as before but faster

## Team reviewers

BOT team
