### PR TITLE
Retrieve line_section disruptions

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -487,8 +487,7 @@ class Disruption(TimestampMixin, db.Model):
 
     @classmethod
     @paginate()
-    def all_with_filter(cls, contributor_id, publication_status, tags, uri,
-                        statuses):
+    def all_with_filter(cls, contributor_id, publication_status, tags, uri, line_section, statuses):
         availlable_filters = {
             'past': and_(cls.end_publication_date != None, cls.end_publication_date < get_current_time()),
             'ongoing': and_(cls.start_publication_date <= get_current_time(),
@@ -508,41 +507,25 @@ class Disruption(TimestampMixin, db.Model):
             query = query.filter(Impact.status == 'published')
             query = query.join(Impact.objects)
 
-            #Here add a new query to find impacts with line =_section having uri as line, start_point or end_point
-            filters = []
-            alias_line = aliased(PTobject)
-            alias_start_point = aliased(PTobject)
-            alias_end_point = aliased(PTobject)
-            alias_route = aliased(PTobject)
-            alias_via = aliased(PTobject)
-            query_line_section = query
-            query_line_section = query_line_section.join(PTobject.line_section)
-            query_line_section = query_line_section.join(alias_line, LineSection.line_object_id == alias_line.id)
-            filters.append(alias_line.uri == uri)
-            query_line_section = query_line_section.join(PTobject, LineSection.object_id == PTobject.id)
-            query_line_section = query_line_section.join(alias_start_point, LineSection.start_object_id == alias_start_point.id)
-            filters.append(alias_start_point.uri == uri)
-            query_line_section = query_line_section.join(alias_end_point, LineSection.end_object_id == alias_end_point.id)
-            filters.append(alias_end_point.uri == uri)
-            query_line_section = query_line_section.join(alias_route, LineSection.routes)
-            filters.append(alias_route.uri == uri)
-            query_line_section = query_line_section.join(alias_via, LineSection.via)
-            filters.append(alias_via.uri == uri)
-            query_line_section = query_line_section.filter(or_(*filters))
+            #Here add a new query to find impacts with line_section having uri as line
+            if line_section :
+                query_line_section = query
+                query_line_section = query_line_section.filter(and_(PTobject.type == "line_section", PTobject.uri.like(uri + ":%")))
 
-            query = query.filter(PTobject.uri == uri)
+        query = query.filter(PTobject.uri == uri)
 
         publication_status = set(publication_status)
         if len(publication_status) == len(publication_status_values):
             #For a query by uri use union with the query for line_section
-            if uri:
+            if uri and line_section:
                 query = query.union_all(query_line_section)
 
         else:
             filters = [availlable_filters[status] for status in publication_status]
             query = query.filter(or_(*filters))
+
             #For a query by uri use union with the query for line_section
-            if uri:
+            if uri and line_section:
                 query_line_section = query_line_section.filter(or_(*filters))
                 query = query.union_all(query_line_section)
 

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -512,7 +512,7 @@ class Disruption(TimestampMixin, db.Model):
                 query_line_section = query
                 query_line_section = query_line_section.filter(and_(PTobject.type == "line_section", PTobject.uri.like(uri + ":%")))
 
-        query = query.filter(PTobject.uri == uri)
+            query = query.filter(PTobject.uri == uri)
 
         publication_status = set(publication_status)
         if len(publication_status) == len(publication_status_values):

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -518,7 +518,7 @@ class Disruption(TimestampMixin, db.Model):
         if len(publication_status) == len(publication_status_values):
             #For a query by uri use union with the query for line_section
             if uri and line_section:
-                query = query.union_all(query_line_section)
+                query = query.union(query_line_section)
 
         else:
             filters = [availlable_filters[status] for status in publication_status]
@@ -527,7 +527,7 @@ class Disruption(TimestampMixin, db.Model):
             #For a query by uri use union with the query for line_section
             if uri and line_section:
                 query_line_section = query_line_section.filter(or_(*filters))
-                query = query.union_all(query_line_section)
+                query = query.union(query_line_section)
 
         return query.order_by(cls.end_publication_date, cls.id)
 

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -174,7 +174,7 @@ class Disruptions(flask_restful.Resource):
                                 action="append")
         parser_get.add_argument("current_time", type=utils.get_datetime)
         parser_get.add_argument("uri", type=str)
-        parser_get.add_argument("line_section", type=bool, default=False)
+        parser_get.add_argument("line_section", type=boolean, default=False)
         parser_get.add_argument(
             "status[]",
             type=option_value(disruption_status_values),

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -28,7 +28,7 @@
 
 from flask import g
 import flask_restful
-from flask_restful import marshal, reqparse
+from flask_restful import marshal, reqparse, types
 from chaos import models, db, publisher
 from jsonschema import validate, ValidationError
 from flask.ext.restful import abort
@@ -174,7 +174,7 @@ class Disruptions(flask_restful.Resource):
                                 action="append")
         parser_get.add_argument("current_time", type=utils.get_datetime)
         parser_get.add_argument("uri", type=str)
-        parser_get.add_argument("line_section", type=boolean, default=False)
+        parser_get.add_argument("line_section", type=types.boolean, default=False)
         parser_get.add_argument(
             "status[]",
             type=option_value(disruption_status_values),

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -174,6 +174,7 @@ class Disruptions(flask_restful.Resource):
                                 action="append")
         parser_get.add_argument("current_time", type=utils.get_datetime)
         parser_get.add_argument("uri", type=str)
+        parser_get.add_argument("line_section", type=bool, default=False)
         parser_get.add_argument(
             "status[]",
             type=option_value(disruption_status_values),
@@ -206,13 +207,13 @@ class Disruptions(flask_restful.Resource):
     def _get_disruptions(self, contributor_id, args):
 
         self._validate_arguments_for_disruption_list(args)
-
         g.current_time = args['current_time']
         page_index = args['start_page']
         items_per_page = args['items_per_page']
         publication_status = args['publication_status[]']
         tags = args['tag[]']
         uri = args['uri']
+        line_section = args['line_section']
         statuses = args['status[]']
 
         result = models.Disruption.all_with_filter(
@@ -222,6 +223,7 @@ class Disruptions(flask_restful.Resource):
             publication_status=publication_status,
             tags=tags,
             uri=uri,
+            line_section=line_section,
             statuses=statuses
         )
 

--- a/documentation/disruptions.md
+++ b/documentation/disruptions.md
@@ -49,6 +49,7 @@ Return all visible disruptions.
 | current_time         | parameter for settings the use by this request, mostly for debugging purpose   | false    | NOW                     |
 | tag[]                | filter by tag (id of tag)                                                      | false    |                         |
 | uri                  | filter by uri of ptobject                                                      | false    |                         |
+| line_section         | if uri is a line id, filter also on related line_section(s)                    | false    | False                   |
 | status[]             | filter by status                                                               | false    | [published, draft]      |
 | depth                | with depth=2, you could retrieve the first page of impacts from the disruption | false    | 1                       |
 

--- a/tests/features/list-disruptions-by-pt-object.feature
+++ b/tests/features/list-disruptions-by-pt-object.feature
@@ -240,8 +240,8 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
 
 
-    #Here we have a disruption un impact, two objects (one object is present also in a line_section of another disruption/impact)
-    #Another disruption with un impact, one object line_section having route and via, another object (network)
+    #Here we have a disruption with one impact, two objects (one object is present also in a line_section of another disruption/impact)
+    #Another disruption with one impact, one object line_section having route and via, another object (network)
     Scenario: Use uri filter to display disruption with impact having line_section, routes and via
         Given I have the following contributors in my database:
             | contributor_code   | created_at          | updated_at          | id                                   |
@@ -321,3 +321,85 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "disruptions" should have a size of 2
         And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
         And the field "disruptions.1.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
+
+
+
+
+
+    # 3 disruptions, impacts line_section and lines
+    # Disruption 1 / 1 impact line
+    # Disruption 2 / 1 impact line_section
+    # Disruption 2 / 1 impact line + 1 impact line_section
+    # We filter disruptions on line uri with line_section parameter
+    Scenario: Use uri filter with line_section filter to display disruption with impact having line_section,
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fii       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 8ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fuu       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 9ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 1ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 2ffab232-3d47-4eea-aa2c-22f8680230b6 | 8ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 3ffab232-3d47-4eea-aa2c-22f8680230b6 | 9ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 4ffab232-3d47-4eea-aa2c-22f8680230b6 | 9ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type         | uri                                              | created_at          | id                                         |
+            | line_section | line:JDR:M1:7ffab234-3d49-4eea-aa2c-22f8680230b6 | 2014-04-04T23:52:12 | 2ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | line_section | line:JDR:M1:8ffab234-3d49-4eea-aa2c-22f8680230b6 | 2014-04-04T23:52:12 | 3ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | line         | line:JDR:M1                                      | 2014-04-06T22:52:12 | 4ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M14                                    | 2014-04-06T22:52:12 | 5ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M1_R                                   | 2014-04-06T22:52:12 | 6ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:NATIO                           | 2014-04-04T23:52:12 | 7ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:REUIL                           | 2014-04-04T23:52:12 | 8ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | line         | line:JDR:M12                                     | 2014-04-04T23:52:12 | 9ffab200-3d48-4eea-aa2c-22f8680230b6       |
+
+        Given I have the following line_section in my database:
+            | id                                    | line_object_id                        | created_at            | updated_at          | start_object_id                      |end_object_id|sens|object_id|
+            | 7ffab234-3d49-4eea-aa2c-22f8680230b6  | 4ffab200-3d48-4eea-aa2c-22f8680230b6  | 2014-04-04T23:52:12   | 2014-04-04T23:52:12 | 7ffab200-3d48-4eea-aa2c-22f8680230b6 |8ffab200-3d48-4eea-aa2c-22f8680230b6|0|2ffab200-3d48-4eea-aa2c-22f8680230b6|
+            | 8ffab234-3d49-4eea-aa2c-22f8680230b6  | 4ffab200-3d48-4eea-aa2c-22f8680230b6  | 2014-04-04T23:52:12   | 2014-04-04T23:52:12 | 7ffab200-3d48-4eea-aa2c-22f8680230b6 |8ffab200-3d48-4eea-aa2c-22f8680230b6|0|3ffab200-3d48-4eea-aa2c-22f8680230b6|
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 9ffab200-3d48-4eea-aa2c-22f8680230b6          | 1ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 3ffab200-3d48-4eea-aa2c-22f8680230b6          | 2ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 4ffab200-3d48-4eea-aa2c-22f8680230b6          | 3ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 2ffab200-3d48-4eea-aa2c-22f8680230b6          | 4ffab232-3d47-4eea-aa2c-22f8680230b6 |
+
+        Given I have the relation associate_line_section_route_object in my database:
+            | route_object_id                               | line_section_id                      |
+            | 5ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+            | 6ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+            | 5ffab200-3d48-4eea-aa2c-22f8680230b6          | 8ffab234-3d49-4eea-aa2c-22f8680230b6 |
+            | 6ffab200-3d48-4eea-aa2c-22f8680230b6          | 8ffab234-3d49-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |affab555-3d47-4eea-aa2c-22f8680230b1 | 1ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |bffab555-3d47-4eea-aa2c-22f8680230b1 | 2ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |cffab555-3d47-4eea-aa2c-22f8680230b1 | 3ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |dffab555-3d47-4eea-aa2c-22f8680230b1 | 4ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        #Query on object 'stop_area:JDR:SA:ESDEN' present in a disruption
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?uri=line:JDR:M1"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"

--- a/tests/features/list-disruptions-by-pt-object.feature
+++ b/tests/features/list-disruptions-by-pt-object.feature
@@ -405,6 +405,15 @@ Feature: list impacts by ptobject and/or uri(s)
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2
 
+        #Query on object 'line:JDR:M1&line_section=false' present in a disruption
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?uri=line:JDR:M1&line_section=false"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+
         #Query on object 'line:JDR:M12' present in a disruption
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"

--- a/tests/features/list-disruptions-by-pt-object.feature
+++ b/tests/features/list-disruptions-by-pt-object.feature
@@ -241,7 +241,7 @@ Feature: list impacts by ptobject and/or uri(s)
 
 
     #Here we have a disruption with one impact, two objects (one object is present also in a line_section of another disruption/impact)
-    #Another disruption with one impact, one object line_section having route and via, another object (network)
+    #Another disruption with one impact, one object line_section having route, another object (network)
     Scenario: Use uri filter to display disruption with impact having line_section, routes and via
         Given I have the following contributors in my database:
             | contributor_code   | created_at          | updated_at          | id                                   |
@@ -294,11 +294,6 @@ Feature: list impacts by ptobject and/or uri(s)
             | 5ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
             | 6ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
 
-        Given I have the relation associate_line_section_via_object in my database:
-            | stop_area_object_id                           | line_section_id                      |
-            | 7ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
-            | 8ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
-
         Given I have the following applicationperiods in my database:
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
@@ -318,11 +313,8 @@ Feature: list impacts by ptobject and/or uri(s)
         When I get "/disruptions?uri=stop_area:JDR:SA:REUIL"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
-        And the field "disruptions" should have a size of 2
-        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
-        And the field "disruptions.1.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
-
-
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.id" should be "8ffab230-3d48-4eea-aa2c-22f8680230b6"
 
 
 
@@ -390,11 +382,11 @@ Feature: list impacts by ptobject and/or uri(s)
         Given I have the following applicationperiods in my database:
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |affab555-3d47-4eea-aa2c-22f8680230b1 | 1ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |bffab555-3d47-4eea-aa2c-22f8680230b1 | 2ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |cffab555-3d47-4eea-aa2c-22f8680230b1 | 3ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |dffab555-3d47-4eea-aa2c-22f8680230b1 | 4ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |bffab555-3d47-4eea-aa2c-22f8680230b1 | 2ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 17:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |cffab555-3d47-4eea-aa2c-22f8680230b1 | 3ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 18:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |dffab555-3d47-4eea-aa2c-22f8680230b1 | 4ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 19:52:00 |
 
-        #Query on object 'stop_area:JDR:SA:ESDEN' present in a disruption
+        #Query on object 'line:JDR:M1' present in a disruption
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
@@ -403,3 +395,22 @@ Feature: list impacts by ptobject and/or uri(s)
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
         And the field "disruptions.0.id" should be "9ffab230-3d48-4eea-aa2c-22f8680230b6"
+
+        #Query on object 'line:JDR:M1&line_section=true' present in a disruption
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?uri=line:JDR:M1&line_section=true"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+
+        #Query on object 'line:JDR:M12' present in a disruption
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?uri=line:JDR:M12"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"


### PR DESCRIPTION
# Description

This PR adds filter on line_section

## Issue (optional)

Issue link: http://jira.canaltp.fr/browse/BOT-42

## Pull Request type (optional)

New feature

## How to test

- Create some disruptions/impacts on line_sections and lines,
- Call api disruptions with :
    filter uri
    then filter uri + line_section=true
- Check response and retrieve your related disruptions/impacts