### PR TITLE
bot-45 End-publication-dates filters

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -487,7 +487,7 @@ class Disruption(TimestampMixin, db.Model):
 
     @classmethod
     @paginate()
-    def all_with_filter(cls, contributor_id, publication_status, end_publication_startfilter_date, end_publication_endfilter_date, tags, uri, line_section, statuses):
+    def all_with_filter(cls, contributor_id, publication_status, ends_after_date, ends_before_date, tags, uri, line_section, statuses):
         availlable_filters = {
             'past': and_(cls.end_publication_date != None, cls.end_publication_date < get_current_time()),
             'ongoing': and_(cls.start_publication_date <= get_current_time(),
@@ -499,11 +499,11 @@ class Disruption(TimestampMixin, db.Model):
             cls.status.in_(statuses)
         ))
 
-        if end_publication_startfilter_date:
-            query = query.filter(cls.end_publication_date >= end_publication_startfilter_date)
+        if ends_after_date:
+            query = query.filter(cls.end_publication_date >= ends_after_date)
 
-        if end_publication_endfilter_date:
-            query = query.filter(cls.end_publication_date <= end_publication_endfilter_date)
+        if ends_before_date:
+            query = query.filter(cls.end_publication_date <= ends_before_date)
 
         if tags:
             query = query.filter(cls.tags.any(Tag.id.in_(tags)))

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -487,7 +487,7 @@ class Disruption(TimestampMixin, db.Model):
 
     @classmethod
     @paginate()
-    def all_with_filter(cls, contributor_id, publication_status, tags, uri, line_section, statuses):
+    def all_with_filter(cls, contributor_id, publication_status, end_publication_startfilter_date, end_publication_endfilter_date, tags, uri, line_section, statuses):
         availlable_filters = {
             'past': and_(cls.end_publication_date != None, cls.end_publication_date < get_current_time()),
             'ongoing': and_(cls.start_publication_date <= get_current_time(),
@@ -498,6 +498,12 @@ class Disruption(TimestampMixin, db.Model):
             cls.contributor_id == contributor_id,
             cls.status.in_(statuses)
         ))
+
+        if end_publication_startfilter_date:
+            query = query.filter(cls.end_publication_date >= end_publication_startfilter_date)
+
+        if end_publication_endfilter_date:
+            query = query.filter(cls.end_publication_date <= end_publication_endfilter_date)
 
         if tags:
             query = query.filter(cls.tags.any(Tag.id.in_(tags)))

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -169,8 +169,8 @@ class Disruptions(flask_restful.Resource):
                                 type=option_value(publication_status_values),
                                 action="append",
                                 default=publication_status_values)
-        parser_get.add_argument("end_publication_startfilter_date", type=utils.get_datetime),
-        parser_get.add_argument("end_publication_endfilter_date", type=utils.get_datetime),
+        parser_get.add_argument("ends_after_date", type=utils.get_datetime),
+        parser_get.add_argument("ends_before_date", type=utils.get_datetime),
         parser_get.add_argument("tag[]",
                                 type=utils.get_uuid,
                                 action="append")
@@ -213,8 +213,8 @@ class Disruptions(flask_restful.Resource):
         page_index = args['start_page']
         items_per_page = args['items_per_page']
         publication_status = args['publication_status[]']
-        end_publication_startfilter_date = args['end_publication_startfilter_date']
-        end_publication_endfilter_date = args['end_publication_endfilter_date']
+        ends_after_date = args['ends_after_date']
+        ends_before_date = args['ends_before_date']
         tags = args['tag[]']
         uri = args['uri']
         line_section = args['line_section']
@@ -225,8 +225,8 @@ class Disruptions(flask_restful.Resource):
             items_per_page=items_per_page,
             contributor_id=contributor_id,
             publication_status=publication_status,
-            end_publication_startfilter_date=end_publication_startfilter_date,
-            end_publication_endfilter_date=end_publication_endfilter_date,
+            ends_after_date=ends_after_date,
+            ends_before_date=ends_before_date,
             tags=tags,
             uri=uri,
             line_section=line_section,

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -169,6 +169,8 @@ class Disruptions(flask_restful.Resource):
                                 type=option_value(publication_status_values),
                                 action="append",
                                 default=publication_status_values)
+        parser_get.add_argument("end_publication_startfilter_date", type=utils.get_datetime),
+        parser_get.add_argument("end_publication_endfilter_date", type=utils.get_datetime),
         parser_get.add_argument("tag[]",
                                 type=utils.get_uuid,
                                 action="append")
@@ -211,6 +213,8 @@ class Disruptions(flask_restful.Resource):
         page_index = args['start_page']
         items_per_page = args['items_per_page']
         publication_status = args['publication_status[]']
+        end_publication_startfilter_date = args['end_publication_startfilter_date']
+        end_publication_endfilter_date = args['end_publication_endfilter_date']
         tags = args['tag[]']
         uri = args['uri']
         line_section = args['line_section']
@@ -221,6 +225,8 @@ class Disruptions(flask_restful.Resource):
             items_per_page=items_per_page,
             contributor_id=contributor_id,
             publication_status=publication_status,
+            end_publication_startfilter_date=end_publication_startfilter_date,
+            end_publication_endfilter_date=end_publication_endfilter_date,
             tags=tags,
             uri=uri,
             line_section=line_section,

--- a/documentation/disruptions.md
+++ b/documentation/disruptions.md
@@ -46,8 +46,8 @@ Return all visible disruptions.
 | start_page           | index of the first element returned (start at 1)                               | false    | 1                       |
 | items_per_page       | number of items per page                                                       | false    | 20                      |
 | publication_status[] | filter by publication_status, possible value are: past, ongoing, coming        | false    | [past, ongoing, coming] |
-| end_publication_startfilter_date    | start-date restriction for end_publication date     | false    |                     |
-| end_publication_endfilter_date      | end-date restriction for end_publication date       | false    |                     |
+| ends_after_date    | start-date restriction for end_publication date     | false    |                     |
+| ends_before_date      | end-date restriction for end_publication date       | false    |                     |
 | current_time         | parameter for settings the use by this request, mostly for debugging purpose   | false    | NOW                     |
 | tag[]                | filter by tag (id of tag)                                                      | false    |                         |
 | uri                  | filter by uri of ptobject                                                      | false    |                         |

--- a/documentation/disruptions.md
+++ b/documentation/disruptions.md
@@ -46,6 +46,8 @@ Return all visible disruptions.
 | start_page           | index of the first element returned (start at 1)                               | false    | 1                       |
 | items_per_page       | number of items per page                                                       | false    | 20                      |
 | publication_status[] | filter by publication_status, possible value are: past, ongoing, coming        | false    | [past, ongoing, coming] |
+| end_publication_startfilter_date    | start-date restriction for end_publication date     | false    |                     |
+| end_publication_endfilter_date      | end-date restriction for end_publication date       | false    |                     |
 | current_time         | parameter for settings the use by this request, mostly for debugging purpose   | false    | NOW                     |
 | tag[]                | filter by tag (id of tag)                                                      | false    |                         |
 | uri                  | filter by uri of ptobject                                                      | false    |                         |

--- a/tests/features/list-disruptions-with-filter-end-publication-dates.feature
+++ b/tests/features/list-disruptions-with-filter-end-publication-dates.feature
@@ -1,6 +1,6 @@
 Feature: list disruptions with filter on end publication dates
 
-    Scenario: Use end publication startfilter date to display disruptions within 7 days
+    Scenario: Use end publication filters date to display disruptions within 7 days
 
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
@@ -23,13 +23,13 @@ Feature: list disruptions with filter on end publication dates
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-15T23:52:12"
+        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-15T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
         And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
 
-    Scenario: Use end publication startfilter date to display disruptions within 14 days
+    Scenario: Use end publication filters date to display disruptions within 14 days
 
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
@@ -52,9 +52,40 @@ Feature: list disruptions with filter on end publication dates
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-22T23:52:12"
+        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-22T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2
         And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
         And the field "disruptions.1.id" should be "7ffab232-3d48-4eea-aa2c-22f8680230b6"
+
+
+    Scenario: Use end publication ends_after_date to display disruptions within 7 days combined with a publicationStatus filter
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-04-02T23:52:12    | 2014-04-14T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fee       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fuu       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d48-4eea-aa2c-22f8680230b6 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?current_time=2014-05-01T08:52:12Z&publication_status[]=past&ends_after_date=2014-04-15T08:52:12Z"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.id" should be "7ffab232-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "7ffab234-3d48-4eea-aa2c-22f8680230b6"

--- a/tests/features/list-disruptions-with-filter-end-publication-dates.feature
+++ b/tests/features/list-disruptions-with-filter-end-publication-dates.feature
@@ -23,7 +23,7 @@ Feature: list disruptions with filter on end publication dates
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I get "/disruptions?end_publication_startfilter_date=2014-04-08T23:52:12Z&end_publication_endfilter_date=2014-04-15T23:52:12"
+        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-15T23:52:12"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -52,7 +52,7 @@ Feature: list disruptions with filter on end publication dates
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I get "/disruptions?end_publication_startfilter_date=2014-04-08T23:52:12Z&end_publication_endfilter_date=2014-04-22T23:52:12"
+        When I get "/disruptions?ends_after_date=2014-04-08T23:52:12Z&ends_before_date=2014-04-22T23:52:12"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2

--- a/tests/features/list-disruptions-with-filter-end-publication-dates.feature
+++ b/tests/features/list-disruptions-with-filter-end-publication-dates.feature
@@ -1,0 +1,60 @@
+Feature: list disruptions with filter on end publication dates
+
+    Scenario: Use end publication startfilter date to display disruptions within 7 days
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-04-02T23:52:12    | 2014-04-14T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fee       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fuu       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d48-4eea-aa2c-22f8680230b6 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?end_publication_startfilter_date=2014-04-08T23:52:12Z&end_publication_endfilter_date=2014-04-15T23:52:12"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+
+    Scenario: Use end publication startfilter date to display disruptions within 14 days
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 2014-04-02T23:52:12    | 2014-04-14T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fee       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | fuu       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d48-4eea-aa2c-22f8680230b6 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions?end_publication_startfilter_date=2014-04-08T23:52:12Z&end_publication_endfilter_date=2014-04-22T23:52:12"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.id" should be "7ffab232-3d48-4eea-aa2c-22f8680230b6"


### PR DESCRIPTION
# Description

This PR adds restriction filters for end publication dates on disruptions API

## Issue (optional)

Issue link:
jira.canaltp.fr/browse/BOT-45

## How to test

Here are the following steps to test this pull request:
- create various Disruptions with various end publication dates
- call the api disruptions with choosed parameters  end_publication_startfilter_date & OR end_publication_endfilter_date
- check response


Related to https://github.com/CanalTP/RealTimeBundle/pull/383