### PR TITLE
Try optimize traffic reports

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -175,7 +175,7 @@ class Severity(TimestampMixin, db.Model):
     priority = db.Column(db.Integer, unique=False, nullable=True)
     effect = db.Column(SeverityEffect, nullable=True)
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='severity', lazy='joined')
+    client = db.relationship('Client', backref='severity')
     wordings = db.relationship(
         "Wording", secondary=associate_wording_severity, backref="severities"
     )
@@ -226,7 +226,7 @@ class Category(TimestampMixin, db.Model):
         db.Boolean, unique=False, nullable=False, default=True
     )
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='categories', lazy='joined')
+    client = db.relationship('Client', backref='categories')
     __table_args__ = (db.UniqueConstraint(
         'name', 'client_id', name='category_name_client_id_key'
     ),)
@@ -293,7 +293,7 @@ class Cause(TimestampMixin, db.Model):
     wording = db.Column(db.Text, unique=False, nullable=False)
     is_visible = db.Column(db.Boolean, unique=False, nullable=False, default=True)
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='causes', lazy='joined')
+    client = db.relationship('Client', backref='causes')
     category_id = db.Column(UUID, db.ForeignKey(Category.id), nullable=True)
     category = db.relationship('Category', backref='causes', lazy='joined')
     wordings = db.relationship("Wording", secondary=associate_wording_cause, backref="causes")
@@ -351,7 +351,7 @@ class Tag(TimestampMixin, db.Model):
     name = db.Column(db.Text, unique=False, nullable=False)
     is_visible = db.Column(db.Boolean, unique=False, nullable=False, default=True)
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='tags', lazy='joined')
+    client = db.relationship('Client', backref='tags')
     __table_args__ = (db.UniqueConstraint('name', 'client_id', name='tag_name_client_id_key'),)
 
     def __init__(self):
@@ -443,7 +443,7 @@ class Disruption(TimestampMixin, db.Model):
     cause = db.relationship('Cause', backref='disruption', lazy='joined')
     tags = db.relationship("Tag", secondary=associate_disruption_tag, backref="disruptions", lazy='joined')
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='disruptions', lazy='joined')
+    client = db.relationship('Client', backref='disruptions')
     contributor_id = db.Column(UUID, db.ForeignKey(Contributor.id), nullable=False)
     contributor = db.relationship('Contributor', backref='disruptions', lazy='joined')
     version = db.Column(db.Integer, nullable=False, default=1)
@@ -833,7 +833,7 @@ class Channel(TimestampMixin, db.Model):
     content_type = db.Column(db.Text, unique=False, nullable=True)
     is_visible = db.Column(db.Boolean, unique=False, nullable=False, default=True)
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='channels', lazy='joined')
+    client = db.relationship('Client', backref='channels')
     channel_types = db.relationship('ChannelType', backref='channel', lazy='joined')
 
     def __init__(self):
@@ -918,8 +918,8 @@ class LineSection(TimestampMixin, db.Model):
     line = db.relationship('PTobject', foreign_keys=line_object_id)
     start_point = db.relationship('PTobject', foreign_keys=start_object_id)
     end_point = db.relationship('PTobject', foreign_keys=end_object_id)
-    routes = db.relationship("PTobject", secondary=associate_line_section_route_object, lazy='joined')
-    via = db.relationship("PTobject", secondary=associate_line_section_via_object, lazy='joined')
+    routes = db.relationship("PTobject", secondary=associate_line_section_route_object)
+    via = db.relationship("PTobject", secondary=associate_line_section_via_object)
     wordings = db.relationship("Wording", secondary=associate_wording_line_section, backref="linesections")
 
     def delete_wordings(self):
@@ -1027,7 +1027,7 @@ class Property(TimestampMixin, db.Model):
     )
     id = db.Column(UUID, primary_key=True)
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
-    client = db.relationship('Client', backref='properties', lazy='joined')
+    client = db.relationship('Client', backref='properties')
     key = db.Column(db.Text, nullable=False)
     type = db.Column(db.Text, nullable=False)
     disruptions = db.relationship(

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -916,11 +916,11 @@ class LineSection(TimestampMixin, db.Model):
     sens = db.Column(db.Integer, unique=False, nullable=True)
     object_id = db.Column(UUID, db.ForeignKey(PTobject.id))
     line = db.relationship('PTobject', foreign_keys=line_object_id)
-    start_point = db.relationship('PTobject', foreign_keys=start_object_id)
-    end_point = db.relationship('PTobject', foreign_keys=end_object_id)
-    routes = db.relationship("PTobject", secondary=associate_line_section_route_object)
-    via = db.relationship("PTobject", secondary=associate_line_section_via_object)
-    wordings = db.relationship("Wording", secondary=associate_wording_line_section, backref="linesections")
+    start_point = db.relationship('PTobject', foreign_keys=start_object_id, lazy="joined")
+    end_point = db.relationship('PTobject', foreign_keys=end_object_id, lazy="joined")
+    routes = db.relationship("PTobject", secondary=associate_line_section_route_object, lazy="joined")
+    via = db.relationship("PTobject", secondary=associate_line_section_via_object, lazy="joined")
+    wordings = db.relationship("Wording", secondary=associate_wording_line_section, backref="linesections", lazy="joined")
 
     def delete_wordings(self):
         index = len(self.wordings) - 1
@@ -944,6 +944,10 @@ class LineSection(TimestampMixin, db.Model):
     @classmethod
     def get_by_object_id(cls, object_id):
         return cls.query.filter_by(object_id=object_id).first()
+
+    @classmethod
+    def get_by_ids(cls, ids):
+        return cls.query.filter(cls.object_id.in_(ids)).all()
 
 
 class Pattern(TimestampMixin, db.Model):

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -968,10 +968,9 @@ class TrafficReport(flask_restful.Resource):
         # Prepare line sections to get them all in once
         pt_object_ids = []
         for disruption in disruptions:
-            for impact in disruption.impacts:
-                if impact.status == 'published':
-                    for pt_object in impact.objects:
-                        pt_object_ids.append(pt_object.id)
+            for impact in (i for i in disruption.impacts if i.status == 'published'):
+                for pt_object in impact.objects:
+                    pt_object_ids.append(pt_object.id)
 
         line_sections = models.LineSection.get_by_ids(pt_object_ids)
         line_sections_by_objid = {}

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -964,21 +964,7 @@ class TrafficReport(flask_restful.Resource):
         args = self.parsers['get'].parse_args()
         g.current_time = args['current_time']
         disruptions = models.Disruption.traffic_report_filter(contributor.id)
-
-        # Prepare line sections to get them all in once
-        pt_object_ids = []
-        for disruption in disruptions:
-            for impact in disruption.impacts:
-                if impact.status == 'published':
-                    for pt_object in impact.objects:
-                        pt_object_ids.append(pt_object.id)
-
-        line_sections = models.LineSection.get_by_ids(pt_object_ids)
-        line_sections_by_objid = {}
-        for line_section in line_sections:
-            line_sections_by_objid[line_section.object_id] = line_section
-
-        result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid)
+        result = utils.get_traffic_report_objects(disruptions, self.navitia)
         return marshal(
             {
                 'traffic_reports': [value for key, value in result["traffic_report"].items()],

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -964,7 +964,21 @@ class TrafficReport(flask_restful.Resource):
         args = self.parsers['get'].parse_args()
         g.current_time = args['current_time']
         disruptions = models.Disruption.traffic_report_filter(contributor.id)
-        result = utils.get_traffic_report_objects(disruptions, self.navitia)
+
+        # Prepare line sections to get them all in once
+        pt_object_ids = []
+        for disruption in disruptions:
+            for impact in disruption.impacts:
+                if impact.status == 'published':
+                    for pt_object in impact.objects:
+                        pt_object_ids.append(pt_object.id)
+
+        line_sections = models.LineSection.get_by_ids(pt_object_ids)
+        line_sections_by_objid = {}
+        for line_section in line_sections:
+            line_sections_by_objid[line_section.object_id] = line_section
+
+        result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid)
         return marshal(
             {
                 'traffic_reports': [value for key, value in result["traffic_report"].items()],

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -567,7 +567,7 @@ def create_line_section(navitia_object, line_section_obj):
     return line_section
 
 
-def get_traffic_report_objects(disruptions, navitia):
+def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid):
     """
     :param impacts: Sequence of impact (Database object)
     :return: dict
@@ -601,19 +601,6 @@ def get_traffic_report_objects(disruptions, navitia):
     }
 
     result = {'traffic_report': {}, 'impacts_used': []}
-
-    # Prepare line sections to get them all in once
-    pt_object_ids = []
-    for disruption in disruptions:
-        for impact in disruption.impacts:
-            if impact.status == 'published':
-                for pt_object in impact.objects:
-                    pt_object_ids.append(pt_object.id)
-
-    line_sections = chaos.models.LineSection.get_by_ids(pt_object_ids)
-    line_sections_by_objid = {}
-    for line_section in line_sections:
-        line_sections_by_objid[line_section.object_id] = line_section
 
     for disruption in disruptions:
         for impact in disruption.impacts:

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -567,7 +567,7 @@ def create_line_section(navitia_object, line_section_obj):
     return line_section
 
 
-def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid):
+def get_traffic_report_objects(disruptions, navitia):
     """
     :param impacts: Sequence of impact (Database object)
     :return: dict
@@ -601,6 +601,19 @@ def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid):
     }
 
     result = {'traffic_report': {}, 'impacts_used': []}
+
+    # Prepare line sections to get them all in once
+    pt_object_ids = []
+    for disruption in disruptions:
+        for impact in disruption.impacts:
+            if impact.status == 'published':
+                for pt_object in impact.objects:
+                    pt_object_ids.append(pt_object.id)
+
+    line_sections = chaos.models.LineSection.get_by_ids(pt_object_ids)
+    line_sections_by_objid = {}
+    for line_section in line_sections:
+        line_sections_by_objid[line_section.object_id] = line_section
 
     for disruption in disruptions:
         for impact in disruption.impacts:

--- a/docker/honcho_launcher.sh
+++ b/docker/honcho_launcher.sh
@@ -10,4 +10,4 @@ do
 done
 echo
 
-/var/www/Chaos/docker/run.sh
+exec /var/www/Chaos/docker/run.sh

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,4 +3,4 @@
 pip install -r requirements.txt
 ./setup.py build_pbf
 #honcho run ./manage.py db upgrade
-honcho run ./manage.py runserver --host 0.0.0.0 --port 80
+exec honcho run ./manage.py runserver --host 0.0.0.0 --port 80

--- a/migrations/versions/458134a1e5ea_add_indexes_on_line_section.py
+++ b/migrations/versions/458134a1e5ea_add_indexes_on_line_section.py
@@ -1,0 +1,22 @@
+"""add indexes on line_section
+
+Revision ID: 458134a1e5ea
+Revises: e33962db5d9
+Create Date: 2017-07-20 10:17:15.224515
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '458134a1e5ea'
+down_revision = 'e33962db5d9'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ix_line_section_object_id', 'line_section', ['object_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_line_section_object_id')

--- a/migrations/versions/458134a1e5ea_add_indexes_on_line_section.py
+++ b/migrations/versions/458134a1e5ea_add_indexes_on_line_section.py
@@ -8,7 +8,7 @@ Create Date: 2017-07-20 10:17:15.224515
 
 # revision identifiers, used by Alembic.
 revision = '458134a1e5ea'
-down_revision = 'e33962db5d9'
+down_revision = '2c160dff136a'
 
 from alembic import op
 import sqlalchemy as sa

--- a/tests/features/impacts-with-pt-objects.feature
+++ b/tests/features/impacts-with-pt-objects.feature
@@ -506,10 +506,8 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.0.line_section.line.id" should be "line:JDR:M1"
         And the field "impact.objects.0.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.0.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
-        And the field "impact.objects.0.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.0.line_section.routes.0.id" should be "route:JDR:M1"
-        And the field "impact.objects.0.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.0.line_section.routes.1.id" should be "route:JDR:M14"
+        And the field "impact.objects.0.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M1"}"
+        And the field "impact.objects.0.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M14"}"
 
     Scenario: Add an impact in a disruption with one object, line_section with routes valid
 
@@ -551,10 +549,8 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.1.line_section.line.id" should be "line:JDR:M1"
         And the field "impact.objects.1.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.1.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
-        And the field "impact.objects.1.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M1"
-        And the field "impact.objects.1.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M14"
+        And the field "impact.objects.1.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M1"}"
+        And the field "impact.objects.1.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M14"}"
 
     Scenario: Add an impact in a disruption with one object, line_section with routes and via valid
 
@@ -596,10 +592,8 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.1.line_section.line.id" should be "line:JDR:M1"
         And the field "impact.objects.1.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.1.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
-        And the field "impact.objects.1.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M1"
-        And the field "impact.objects.1.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M14"
+        And the field "impact.objects.1.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M1"}"
+        And the field "impact.objects.1.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M14"}"
         And the field "impact.objects.1.line_section.via" should have a size of 2
 
     Scenario: Put impact with line_section : delete line_section

--- a/tests/features/impacts-with-pt-objects.feature
+++ b/tests/features/impacts-with-pt-objects.feature
@@ -507,9 +507,9 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.0.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.0.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
         And the field "impact.objects.0.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.0.line_section.routes.0.id" should be "route:JDR:M14"
+        And the field "impact.objects.0.line_section.routes.0.id" should be "route:JDR:M1"
         And the field "impact.objects.0.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.0.line_section.routes.1.id" should be "route:JDR:M1"
+        And the field "impact.objects.0.line_section.routes.1.id" should be "route:JDR:M14"
 
     Scenario: Add an impact in a disruption with one object, line_section with routes valid
 
@@ -552,9 +552,9 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.1.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.1.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
         And the field "impact.objects.1.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M14"
+        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M1"
         And the field "impact.objects.1.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M1"
+        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M14"
 
     Scenario: Add an impact in a disruption with one object, line_section with routes and via valid
 
@@ -597,9 +597,9 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.1.line_section.start_point.id" should be "stop_area:JDR:SA:PTVIN"
         And the field "impact.objects.1.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
         And the field "impact.objects.1.line_section.routes.0.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M14"
+        And the field "impact.objects.1.line_section.routes.0.id" should be "route:JDR:M1"
         And the field "impact.objects.1.line_section.routes.1.type" should be "route"
-        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M1"
+        And the field "impact.objects.1.line_section.routes.1.id" should be "route:JDR:M14"
         And the field "impact.objects.1.line_section.via" should have a size of 2
 
     Scenario: Put impact with line_section : delete line_section

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1014,9 +1014,9 @@ Feature: traffic report api
         And the field "traffic_reports.0.line_sections.0.line_section.line.code" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.routes" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.routes" should have a size of 2
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.0.id" should be "route:JDR:M14"
+        And the field "traffic_reports.0.line_sections.0.line_section.routes.0.id" should be "route:JDR:M1_R"
         And the field "traffic_reports.0.line_sections.0.line_section.routes.0.type" should be "route"
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.1.id" should be "route:JDR:M1_R"
+        And the field "traffic_reports.0.line_sections.0.line_section.routes.1.id" should be "route:JDR:M14"
         And the field "traffic_reports.0.line_sections.0.line_section.routes.1.type" should be "route"
         And the field "traffic_reports.0.line_sections.0.line_section.via" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.via" should have a size of 2

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1014,10 +1014,8 @@ Feature: traffic report api
         And the field "traffic_reports.0.line_sections.0.line_section.line.code" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.routes" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.routes" should have a size of 2
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.0.id" should be "route:JDR:M1_R"
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.0.type" should be "route"
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.1.id" should be "route:JDR:M14"
-        And the field "traffic_reports.0.line_sections.0.line_section.routes.1.type" should be "route"
+        And the field "traffic_reports.0.line_sections.0.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M1_R"}"
+        And the field "traffic_reports.0.line_sections.0.line_section.routes" should contain all of "{"type": "route", "id": "route:JDR:M14"}"
         And the field "traffic_reports.0.line_sections.0.line_section.via" should exist
         And the field "traffic_reports.0.line_sections.0.line_section.via" should have a size of 2
         And the field "traffic_reports.0.network.id" should be "network:JDR:1"

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -4,7 +4,7 @@ import os
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'
+SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'))
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
 

--- a/tests/traffic_reports_test.py
+++ b/tests/traffic_reports_test.py
@@ -9,13 +9,13 @@ class Obj(object):
 
 
 def test_get_traffic_report_objects():
-    dd = get_traffic_report_objects([], Obj())
+    dd = get_traffic_report_objects([], Obj(), {})
     eq_(len(dd["traffic_report"].items()), 0)
 
 
 def test_get_traffic_report_without_objects():
     disruption = chaos.models.Disruption()
-    dd = get_traffic_report_objects([disruption], Obj())
+    dd = get_traffic_report_objects([disruption], Obj(), {})
     eq_(len(dd["traffic_report"].items()), 0)
 
 
@@ -63,7 +63,7 @@ def test_get_traffic_report_with_network():
             }
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, {})
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -140,7 +140,7 @@ def test_get_traffic_report_with_impact_on_lines():
             "lines": [{'id': 'line:uri2', 'name': 'line 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, {})
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -178,7 +178,7 @@ def test_get_traffic_report_with_impact_on_networks():
             }
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, {})
 
     eq_(cmp(dd["traffic_report"], result), 0)
 
@@ -205,7 +205,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_one_network():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, {})
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -238,7 +238,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
             "stop_areas": [{'id': 'stop_area:uri2', 'name': 'stop area 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, {})
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -279,7 +279,7 @@ def test_get_traffic_report_with_2_impact_on_stop_area():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": impacts}]
         }
     }
-    dd = get_traffic_report_objects(disruptions, navitia)
+    dd = get_traffic_report_objects(disruptions, navitia, {})
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -346,5 +346,5 @@ def test_get_traffic_report_with_impact_on_line_sections():
             ]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia)
+    dd = get_traffic_report_objects([disruption], navitia, { ptobject.id: ptobject.line_section })
     eq_(cmp(dd["traffic_report"], result), 0)


### PR DESCRIPTION
# Description

This PR tries to optimize a little traffic_reports calls.
On my env, I go from 8s to 2.5s. But not sure it will be the same in production...

## Issue (optional)

Issue link:

## Pull Request type (optional)

This is an attempt for performance improvement

## How to test

Here are the following steps to test this pull request:

- Try to use traffic_reports, it should be (a little) quicker
- Nothing should be broken

## Team reviewers (optional)

@CanalTP/bot 
