### PR TITLE
Update filter impacts for line_section

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -37,6 +37,7 @@ from datetime import datetime
 from formats import publication_status_values
 from sqlalchemy import or_, and_, between
 from sqlalchemy.orm import aliased
+import logging
 
 
 # force the server to use UTC time for each connection
@@ -724,14 +725,10 @@ class Impact(TimestampMixin, db.Model):
 
         if pt_object_type:
             query = query.filter(pt_object_alias.type == pt_object_type)
-            if line_section:
-                pt_object_filters = []
-                pt_object_filters.append(alias_line.type == pt_object_type)
-                pt_object_filters.append(alias_start_point.type == pt_object_type)
-                pt_object_filters.append(alias_end_point.type == pt_object_type)
-                pt_object_filters.append(alias_route.type == pt_object_type)
-                pt_object_filters.append(alias_via.type == pt_object_type)
-                query_line_section = query_line_section.filter(or_(*pt_object_filters))
+            if line_section and pt_object_type == 'route':
+                query_line_section = query_line_section.filter(alias_route.type == pt_object_type)
+            elif pt_object_type not in ['line_section', 'line', 'stop_area']:
+                line_section = False
 
         if uris:
             query = query.filter(pt_object_alias.uri.in_(uris))

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -687,6 +687,7 @@ class ImpactsByObject(flask_restful.Resource):
         parser_get.add_argument("start_date", type=utils.get_datetime, default=default_start_date)
         parser_get.add_argument("end_date", type=utils.get_datetime, default=default_end_date)
         parser_get.add_argument("uri[]", type=str, action="append")
+        parser_get.add_argument("line_section", type=types.boolean, default=False)
         self.navitia = None
 
     @validate_contributor()
@@ -699,11 +700,18 @@ class ImpactsByObject(flask_restful.Resource):
         start_date = args['start_date']
         end_date = args['end_date']
         uris = args['uri[]']
+        line_section = args['line_section']
 
         if not pt_object_type and not uris:
                 return marshal({'error': {'message': "object type or uri object invalid"}},
                                error_fields), 400
-        impacts = models.Impact.all_with_filter(start_date, end_date, pt_object_type, uris, contributor.id)
+        impacts = models.Impact.all_with_filter(
+            start_date,
+            end_date,
+            pt_object_type,
+            uris,
+            contributor.id,
+            line_section)
         result = utils.group_impacts_by_pt_object(impacts, pt_object_type, uris, self.navitia.get_pt_object)
         return marshal({'objects': result}, impacts_by_object_fields)
 

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -687,7 +687,6 @@ class ImpactsByObject(flask_restful.Resource):
         parser_get.add_argument("start_date", type=utils.get_datetime, default=default_start_date)
         parser_get.add_argument("end_date", type=utils.get_datetime, default=default_end_date)
         parser_get.add_argument("uri[]", type=str, action="append")
-        parser_get.add_argument("line_section", type=types.boolean, default=False)
         self.navitia = None
 
     @validate_contributor()
@@ -700,7 +699,6 @@ class ImpactsByObject(flask_restful.Resource):
         start_date = args['start_date']
         end_date = args['end_date']
         uris = args['uri[]']
-        line_section = args['line_section']
 
         if not pt_object_type and not uris:
                 return marshal({'error': {'message': "object type or uri object invalid"}},
@@ -710,8 +708,7 @@ class ImpactsByObject(flask_restful.Resource):
             end_date,
             pt_object_type,
             uris,
-            contributor.id,
-            line_section)
+            contributor.id)
         result = utils.group_impacts_by_pt_object(impacts, pt_object_type, uris, self.navitia.get_pt_object)
         return marshal({'objects': result}, impacts_by_object_fields)
 

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -271,6 +271,8 @@ def get_object_in_line_section_by_type(pt_object, object_type):
             return object.start_point
         if object.end_point.type == object_type:
             return object.end_point
+        if object.routes and object.routes[0].type == object_type:
+            return object.routes[0]
     return None
 
 

--- a/tests/features/list-impacts-by-pt-object-uri.feature
+++ b/tests/features/list-impacts-by-pt-object-uri.feature
@@ -552,7 +552,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in via et route of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1

--- a/tests/features/list-impacts-by-pt-object-uri.feature
+++ b/tests/features/list-impacts-by-pt-object-uri.feature
@@ -520,7 +520,7 @@ Feature: list impacts by ptobject and/or uri(s)
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by uri of object in start_point of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:BASTI&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:BASTI&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -528,7 +528,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in line of line_section
-        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -536,7 +536,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in route of line_section
-        When I get "/impacts?uri[]=route:JDR:M14&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=route:JDR:M14&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -544,7 +544,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in via of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:REUIL&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:REUIL&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -552,7 +552,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in via et route of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -622,7 +622,7 @@ Feature: list impacts by ptobject and/or uri(s)
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by uri of object in start_point of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -689,7 +689,7 @@ Feature: list impacts by ptobject and/or uri(s)
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by uri of object in start_point of line_section
-        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1

--- a/tests/features/list-impacts-by-pt-object-uri.feature
+++ b/tests/features/list-impacts-by-pt-object-uri.feature
@@ -630,3 +630,68 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
         And the field "objects.0.impacts.1.objects.0.type" should be "stop_area"
         And the field "objects.0.impacts.1.objects.0.id" should be "stop_area:JDR:SA:NATIO"
+
+    Scenario: Filter on uri of an object in line_section to display impacts (no via)
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 8ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type         | uri                                              | created_at          | id                                         |
+            | stop_area    | stop_area:JDR:SA:BASTI                           | 2014-04-04T23:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:CHVIN                           | 2014-04-04T23:52:12 | 2ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line_section | line:JDR:M1:7ffab234-3d49-4eea-aa2c-22f8680230b6 | 2014-04-04T23:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line         | line:JDR:M1                                      | 2014-04-06T22:52:12 | 4ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M14                                    | 2014-04-06T22:52:12 | 5ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M1_R                                   | 2014-04-06T22:52:12 | 6ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:NATIO                           | 2014-04-04T23:52:12 | 7ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:REUIL                           | 2014-04-04T23:52:12 | 8ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | network      | network:TAD:CanalTP                              | 2014-04-04T23:52:12 | 9ffab232-3d48-4eea-aa2c-22f8680230b6       |
+
+        Given I have the following line_section in my database:
+            | id                                    | line_object_id                        | created_at            | updated_at          | start_object_id                      |end_object_id|sens|object_id|
+            | 7ffab234-3d49-4eea-aa2c-22f8680230b6  | 4ffab232-3d48-4eea-aa2c-22f8680230b6  | 2014-04-04T23:52:12   | 2014-04-04T23:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6 |2ffab232-3d48-4eea-aa2c-22f8680230b6|0|3ffab232-3d48-4eea-aa2c-22f8680230b6|
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 9ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 7ffab232-3d48-4eea-aa2c-22f8680230b6          | 8ffab232-3d47-4eea-aa2c-22f8680230b6 |
+
+        Given I have the relation associate_line_section_route_object in my database:
+            | route_object_id                               | line_section_id                      |
+            | 5ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+            | 6ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:50:00                  |2014-01-30 16:50:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |8ffab232-3d47-4eea-aa2c-22f8680230b1 | 8ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        #Fetch impact by uri of object in start_point of line_section
+        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "objects" should have a size of 1
+        And the field "objects.0.impacts" should have a size of 1
+        And the field "objects.0.impacts.0.objects" should have a size of 2

--- a/tests/features/list-impacts-by-pt-object-uri.feature
+++ b/tests/features/list-impacts-by-pt-object-uri.feature
@@ -520,7 +520,7 @@ Feature: list impacts by ptobject and/or uri(s)
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by uri of object in start_point of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:BASTI&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:BASTI&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -528,7 +528,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in line of line_section
-        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=line:JDR:M1&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -536,7 +536,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in route of line_section
-        When I get "/impacts?uri[]=route:JDR:M14&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=route:JDR:M14&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -544,7 +544,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in via of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:REUIL&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:REUIL&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -552,7 +552,7 @@ Feature: list impacts by ptobject and/or uri(s)
         And the field "objects.0.impacts.0.objects" should have a size of 2
 
         #Fetch impact by uri of object in via et route of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&uri[]=route:JDR:M1_R&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -622,7 +622,7 @@ Feature: list impacts by ptobject and/or uri(s)
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by uri of object in start_point of line_section
-        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?uri[]=stop_area:JDR:SA:NATIO&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1

--- a/tests/features/list-impacts-by-pt-object.feature
+++ b/tests/features/list-impacts-by-pt-object.feature
@@ -654,7 +654,7 @@ Feature: list impacts by ptobject
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by type of object in start_point, end_point and line of line_section
-        When I get "/impacts?pt_object_type=stop_area&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?pt_object_type=stop_area&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -664,7 +664,7 @@ Feature: list impacts by ptobject
         And the field "objects.0.impacts.0.objects.0.line_section.start_point.id" should be "stop_area:JDR:SA:BASTI"
 
         #Fetch impact by type of object in start_point, end_point and line of line_section
-        When I get "/impacts?pt_object_type=network&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
+        When I get "/impacts?pt_object_type=network&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 0

--- a/tests/features/list-impacts-by-pt-object.feature
+++ b/tests/features/list-impacts-by-pt-object.feature
@@ -654,7 +654,7 @@ Feature: list impacts by ptobject
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         #Fetch impact by type of object in start_point, end_point and line of line_section
-        When I get "/impacts?pt_object_type=stop_area&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?pt_object_type=stop_area&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 1
@@ -664,7 +664,7 @@ Feature: list impacts by ptobject
         And the field "objects.0.impacts.0.objects.0.line_section.start_point.id" should be "stop_area:JDR:SA:BASTI"
 
         #Fetch impact by type of object in start_point, end_point and line of line_section
-        When I get "/impacts?pt_object_type=network&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z&line_section=true"
+        When I get "/impacts?pt_object_type=network&start_date=2013-12-02T23:52:12Z&end_date=2014-10-21T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "objects" should have a size of 0


### PR DESCRIPTION
# Description

This PR add the return of line_section objects from URI /impacts in order to show them on the calendar part in NMM

## Issue

Issue link: BOT-134

## How to test

Here are the following steps to test this pull request:

- Create an impact with a line_section objects
- Call chaos API /impacts with parameters : uri[]={line_uri_of_line_section}
- You should retrieve the impact
