### PR TITLE
Add ptobject filter on traffic reports

### DIFF
--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -989,7 +989,6 @@ class TrafficReport(flask_restful.Resource):
         self.parsers["get"] = reqparse.RequestParser()
         parser_get = self.parsers["get"]
         parser_get.add_argument("current_time", type=utils.get_datetime, default=utils.get_current_time())
-        parser_get.add_argument("ptObjectFilter", location='json')
         self.navitia = None
 
     @validate_contributor()
@@ -999,11 +998,13 @@ class TrafficReport(flask_restful.Resource):
     def get(self, contributor, navitia):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
+        body = (json.loads(request.data) if request.data else None)
         g.current_time = args['current_time']
         disruptions = models.Disruption.traffic_report_filter(contributor.id)
 
         # Filter disruptions by PtObject
-        utils.filter_disruptions_by_ptobjects(disruptions, args['ptObjectFilter'])
+        if body and body.get('ptObjectFilter', []):
+            utils.filter_disruptions_by_ptobjects(disruptions, body['ptObjectFilter'])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -989,6 +989,7 @@ class TrafficReport(flask_restful.Resource):
         self.parsers["get"] = reqparse.RequestParser()
         parser_get = self.parsers["get"]
         parser_get.add_argument("current_time", type=utils.get_datetime, default=utils.get_current_time())
+        parser_get.add_argument("ptObjectFilter", location='json')
         self.navitia = None
 
     @validate_contributor()
@@ -1000,6 +1001,9 @@ class TrafficReport(flask_restful.Resource):
         args = self.parsers['get'].parse_args()
         g.current_time = args['current_time']
         disruptions = models.Disruption.traffic_report_filter(contributor.id)
+
+        # Filter disruptions by PtObject
+        utils.filter_disruptions_by_ptobjects(disruptions, args['ptObjectFilter'])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -703,24 +703,24 @@ def filter_disruptions_by_ptobjects(disruptions, filter):
         :return: Nothing
         :rtype: Void
     """
-
-    if filter is not None:
-        for disruption in disruptions[:]:
-            disruption_is_deleted = False
-            for impact in (i for i in disruption.impacts if i.status == 'published'):
-                for pt_object in impact.objects:
-                    if hasattr(filter, pt_object.type + 's'):
-                        if pt_object.uri not in filter[pt_object.type + 's']:
-                            disruption_is_deleted = True
-                            break
-                    elif pt_object.type == 'line_section' and hasattr(filter, 'lines'):
-                        if pt_object.uri[:-36] not in filter['lines']:
-                            disruption_is_deleted = True
-                            break
-                    else:
+    if filter is None:
+        return
+    for disruption in disruptions[:]:
+        disruption_is_deleted = False
+        for impact in (i for i in disruption.impacts if i.status == 'published'):
+            for pt_object in impact.objects:
+                if filter.get(pt_object.type + 's', []):
+                    if pt_object.uri not in filter[pt_object.type + 's']:
                         disruption_is_deleted = True
                         break
-                if disruption_is_deleted:
+                elif pt_object.type == 'line_section' and filter.get('lines', []):
+                    if pt_object.uri[:-37] not in filter['lines']:
+                        disruption_is_deleted = True
+                        break
+                else:
+                    disruption_is_deleted = True
                     break
             if disruption_is_deleted:
-                disruptions.remove(disruption)
+                break
+        if disruption_is_deleted:
+            disruptions.remove(disruption)

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -696,15 +696,13 @@ def raise_client_token_error(message):
 
 def filter_disruptions_by_ptobjects(disruptions, filter):
     """
-        Logs message and raises an exception with this message
+        Do filter in disruptions.
 
         :param disruptions: Sequence of disruption (Database object)
         :param filter: json
         :return: Nothing
         :rtype: Void
     """
-    if filter is None:
-        return
     for disruption in disruptions[:]:
         disruption_is_deleted = False
         for impact in (i for i in disruption.impacts if i.status == 'published'):
@@ -721,6 +719,5 @@ def filter_disruptions_by_ptobjects(disruptions, filter):
                     disruption_is_deleted = True
                     break
             if disruption_is_deleted:
+                disruptions.remove(disruption)
                 break
-        if disruption_is_deleted:
-            disruptions.remove(disruption)

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1327,3 +1327,211 @@ Feature: traffic report api
         And the field "traffic_reports.0.lines.0.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b2"
         And the field "traffic_reports.0.stop_areas" should have a size of 2
         And the field "traffic_reports.0.stop_points" should have a size of 2
+
+    Scenario: One network with filter on network  : http://jira.canaltp.fr/browse/BOT-503
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date|end_publication_date|
+            | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type          | uri                                       | created_at          | updated_at          | id                                         |
+            | network       | network:JDR:2                             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b1       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b1       | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        """
+        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        """
+        Then the status code should be "200"
+        And the field "disruptions" should have a size of 1
+        And the field "traffic_reports" should have a size of 1
+        And the field "traffic_reports.0.network.id" should be "network:JDR:2"
+        And the field "traffic_reports.0.network.name" should be "SNCF"
+        And the field "traffic_reports.0.network.links" should exist
+        And the field "traffic_reports.0.network.links" should have a size of 1
+        And the field "traffic_reports.0.network.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b1"
+
+    Scenario: One network, one line, with filter on network  : http://jira.canaltp.fr/browse/BOT-503
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date|end_publication_date|
+            | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type          | uri                                       | created_at          | updated_at          | id                                         |
+            | network       | network:JDR:2                             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b1       |
+            | line          | line:JDR:TGV                              | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b2       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b1       | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b2       | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        """
+        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        """
+        Then the status code should be "200"
+        And the field "disruptions" should have a size of 0
+        And the field "traffic_reports" should have a size of 0
+
+    Scenario: One network, one line, with filter on network and line  : http://jira.canaltp.fr/browse/BOT-503
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date|end_publication_date|
+            | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type          | uri                                       | created_at          | updated_at          | id                                         |
+            | network       | network:JDR:2                             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b1       |
+            | line          | line:JDR:TGV                              | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b2       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b1       | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b2       | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        """
+        {"ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
+        """
+        Then the status code should be "200"
+        And the field "disruptions" should have a size of 2
+        And the field "traffic_reports" should have a size of 1
+        And the field "traffic_reports.0.network.id" should be "network:JDR:2"
+        And the field "traffic_reports.0.network.name" should be "SNCF"
+        And the field "traffic_reports.0.network.links" should have a size of 1
+        And the field "traffic_reports.0.network.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b1"
+        And the field "traffic_reports.0.lines" should have a size of 1
+        And the field "traffic_reports.0.lines.0.id" should be "line:JDR:TGV"
+        And the field "traffic_reports.0.lines.0.links" should have a size of 1
+        And the field "traffic_reports.0.lines.0.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b2"
+
+    Scenario: 2 impacts with one on 2 networks and another on one network and filter on one network
+#
+#                       |                       01-01-2014                                  02-02-2014
+#  publication_period   |                           +-------------------------------------------+
+#                       |                                       20-01-2014      30-01-2014
+#  application_period   |                                           +------------------+
+#                       |
+# PtObject: network:JDR:1
+# PtObject: network:JDR:2
+#
+#
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date|end_publication_date|
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+            | foo1      | hello1| 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00|2014-02-02 16:52:00|
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b7 | 7ffab230-3d48-4eea-aa2c-22f8680230b1 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type      | uri                    | created_at          | updated_at          | id                                         |
+            | network   | network:JDR:1          | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | network   | network:JDR:2          | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b7       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b7       | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 1ffab232-3d48-4eea-aa2c-22f8680230b7       | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:53:00                  |2014-01-30 16:52:00 |
+
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        """
+        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        """
+        Then the status code should be "200"
+        And the field "disruptions" should have a size of 1
+        And the field "traffic_reports" should have a size of 1
+        And the field "traffic_reports.0.network.id" should be "network:JDR:2"
+        And the field "traffic_reports.0.network.name" should be "SNCF"
+        And the field "traffic_reports.0.network.links" should have a size of 1
+        And the field "traffic_reports.0.network.links.0.id" should be "7ffab232-3d47-4eea-aa2c-22f8680230b7"


### PR DESCRIPTION
# Description

This PR add a parameter (in body because of the possible length of the value) to filter traffic_report API with ptobject list

## Issue

Issue link: BOT-503

## Test

For testing purpose, use curl command -> exemple : 
```
curl -X GET 'http://ip_chaos/traffic_reports' -H 'Authorization: d967e37e-7078-40ca-9763-efec48e86660' -H 'Content-Type: application/json' -H 'X-Contributors: shortterm.tr_transilien' -H 'X-Customer-id: transilien' -H 'X-Coverage: transilien' -d '{"ptObjectFilter": {"networks": ["network:DUA801"], "lines": ["line:DUA:810801041"]}}'
```
