### PR TITLE
Update traffic_report call to post

### DIFF
--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -7,6 +7,7 @@ SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql:/
 DEBUG = (os.getenv('DEBUG', 1) == 1)
 
 NAVITIA_URL = str(os.getenv('NAVITIA_URL', 'http://navitia2-ws.ctp.dev.canaltp.fr'))
+NAVITIA_TIMEOUT = os.getenv('NAVITIA_TIMEOUT', 1)
 
 # rabbitmq connections string: http://kombu.readthedocs.org/en/latest/userguide/connections.html#urls
 RABBITMQ_CONNECTION_STRING = str(

--- a/chaos/navitia.py
+++ b/chaos/navitia.py
@@ -37,7 +37,7 @@ __all__ = ['Navitia']
 
 
 class Navitia(object):
-    def __init__(self, url, coverage, token=None, timeout=1):
+    def __init__(self, url, coverage, token=None, timeout=app.config['NAVITIA_TIMEOUT']):
         self.url = url
         self.coverage = coverage
         self.token = token

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -996,15 +996,26 @@ class TrafficReport(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     def get(self, contributor, navitia):
+        return self._get_traffic_report(contributor.id, navitia)
+
+    @validate_contributor()
+    @validate_navitia()
+    @manage_navitia_error()
+    @validate_client_token()
+    def post(self, contributor, navitia):
+        json = (request.get_json(silent=True) or {})
+        return self._get_traffic_report(contributor.id, navitia, json)
+
+    def _get_traffic_report(self, contributor_id, navitia, json={}):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
-        body = (json.loads(request.data) if request.data else None)
-        g.current_time = args['current_time']
-        disruptions = models.Disruption.traffic_report_filter(contributor.id)
+        g.current_time = (utils.get_datetime(json.get('current_time'), 'current_time') if json.get('current_time')
+            else args['current_time'])
+        disruptions = models.Disruption.traffic_report_filter(contributor_id)
 
         # Filter disruptions by PtObject
-        if body and body.get('ptObjectFilter', []):
-            utils.filter_disruptions_by_ptobjects(disruptions, body['ptObjectFilter'])
+        if json.get('ptObjectFilter', []):
+            utils.filter_disruptions_by_ptobjects(disruptions, json['ptObjectFilter'])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []
@@ -1026,7 +1037,6 @@ class TrafficReport(flask_restful.Resource):
             },
             traffic_reports_marshaler
         ), 200
-
 
 class Property(flask_restful.Resource):
     def __init__(self):

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1003,19 +1003,20 @@ class TrafficReport(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     def post(self, contributor, navitia):
-        json = (request.get_json(silent=True) or {})
-        return self._get_traffic_report(contributor.id, navitia, json)
+        body_json = (request.get_json(silent=True) or {})
+        return self._get_traffic_report(contributor.id, navitia, body_json)
 
-    def _get_traffic_report(self, contributor_id, navitia, json={}):
+    def _get_traffic_report(self, contributor_id, navitia, body_json={}):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
-        g.current_time = (utils.get_datetime(json.get('current_time'), 'current_time') if json.get('current_time')
-            else args['current_time'])
+        g.current_time = (utils.get_datetime(body_json.get('current_time'), 'current_time')
+                          if body_json.get('current_time')
+                          else args['current_time'])
         disruptions = models.Disruption.traffic_report_filter(contributor_id)
 
         # Filter disruptions by PtObject
-        if json.get('ptObjectFilter', []):
-            utils.filter_disruptions_by_ptobjects(disruptions, json['ptObjectFilter'])
+        if body_json.get('ptObjectFilter', []):
+            utils.filter_disruptions_by_ptobjects(disruptions, body_json['ptObjectFilter'])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []
@@ -1032,7 +1033,7 @@ class TrafficReport(flask_restful.Resource):
         result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid)
         return marshal(
             {
-                'traffic_reports': [value for key, value in result["traffic_report"].items()],
+                'traffic_reports': [value for value in result["traffic_report"].items()],
                 'disruptions': result["impacts_used"]
             },
             traffic_reports_marshaler

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1033,7 +1033,7 @@ class TrafficReport(flask_restful.Resource):
         result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid)
         return marshal(
             {
-                'traffic_reports': [value for value in result["traffic_report"].items()],
+                'traffic_reports': [value for key, value in result["traffic_report"].items()],
                 'disruptions': result["impacts_used"]
             },
             traffic_reports_marshaler

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1003,12 +1003,13 @@ class TrafficReport(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     def post(self, contributor, navitia):
-        body_json = (request.get_json(silent=True) or {})
-        return self._get_traffic_report(contributor.id, navitia, body_json)
+        return self._get_traffic_report(contributor.id, navitia, request.get_json(silent=True))
 
-    def _get_traffic_report(self, contributor_id, navitia, body_json={}):
+    def _get_traffic_report(self, contributor_id, navitia, body_json=None):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
+        if body_json is None:
+            body_json = {}
         g.current_time = (utils.get_datetime(body_json.get('current_time'), 'current_time')
                           if body_json.get('current_time')
                           else args['current_time'])

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -8,7 +8,7 @@ Feature: traffic report api
 
     Scenario: response of traffic report api without "X-Contributors"
         I remove header "X-Contributors"
-        When I post to "/traffic_reports"
+        When I get "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter X-Contributors does not exist in the header"
@@ -18,7 +18,7 @@ Feature: traffic report api
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         I remove header "X-Coverage"
-        When I post to "/traffic_reports"
+        When I get "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter X-Coverage does not exist in the header"
@@ -28,7 +28,7 @@ Feature: traffic report api
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         I remove header "Authorization"
-        When I post to "/traffic_reports"
+        When I get "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter Authorization does not exist in the header"
@@ -37,7 +37,7 @@ Feature: traffic report api
         Given I have the following contributors in my database:
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-        When I post to "/traffic_reports"
+        When I get "/traffic_reports"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
 
@@ -85,10 +85,7 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2013-12-15T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2013-12-15T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
@@ -138,10 +135,7 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-15T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-15T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -199,10 +193,7 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-23T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -260,10 +251,7 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-02-01T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-02-01T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -321,10 +309,7 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-02-15T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-02-15T23:52:12Z"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
@@ -375,10 +360,7 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b0 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-02-20 16:52:00                  |2014-02-28 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2013-12-15T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2013-12-15T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 0
@@ -429,10 +411,7 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b0 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-02-20 16:52:00                  |2014-02-28 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-02-02T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-02-02T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -489,10 +468,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-23T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -554,10 +530,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-23T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -618,10 +591,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-23T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -688,10 +658,7 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-05 16:52:00                  |2014-01-10 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-15T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-15T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -757,10 +724,7 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-15 16:52:00                  |2014-02-05 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-17T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -819,10 +783,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-17T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -887,10 +848,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-17T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -978,10 +936,7 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-17T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -1089,10 +1044,7 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I post to "/traffic_reports" with:
-    """
-    {"current_time": "2014-01-17T23:52:12Z"}
-    """
+    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -1150,10 +1102,7 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:53:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-21T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
         Then the status code should be "200"
         And the field "disruptions" should have a size of 2
         And the field "traffic_reports" should have a size of 2
@@ -1217,10 +1166,7 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab232-3d47-4eea-aa2c-22f8680230b3 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-21T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
         Then the status code should be "200"
         And the field "disruptions" should have a size of 4
         And the field "traffic_reports" should have a size of 1
@@ -1297,10 +1243,7 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-21T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
         Then the status code should be "200"
         And the field "disruptions" should have a size of 6
         And the field "traffic_reports" should have a size of 1
@@ -1371,10 +1314,7 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I post to "/traffic_reports" with:
-        """
-        {"current_time": "2014-01-21T23:52:12Z"}
-        """
+        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
         Then the status code should be "200"
         And the field "disruptions" should have a size of 5
         And the field "traffic_reports" should have a size of 1

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -8,7 +8,7 @@ Feature: traffic report api
 
     Scenario: response of traffic report api without "X-Contributors"
         I remove header "X-Contributors"
-        When I get "/traffic_reports"
+        When I post to "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter X-Contributors does not exist in the header"
@@ -18,7 +18,7 @@ Feature: traffic report api
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         I remove header "X-Coverage"
-        When I get "/traffic_reports"
+        When I post to "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter X-Coverage does not exist in the header"
@@ -28,7 +28,7 @@ Feature: traffic report api
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         I remove header "Authorization"
-        When I get "/traffic_reports"
+        When I post to "/traffic_reports"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The parameter Authorization does not exist in the header"
@@ -37,7 +37,7 @@ Feature: traffic report api
         Given I have the following contributors in my database:
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-        When I get "/traffic_reports"
+        When I post to "/traffic_reports"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
 
@@ -85,7 +85,10 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2013-12-15T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2013-12-15T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
@@ -135,7 +138,10 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-15T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-15T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -193,7 +199,10 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-23T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -251,7 +260,10 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-02-01T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-02-01T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
@@ -309,7 +321,10 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-02-15T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-02-15T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
@@ -360,7 +375,10 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b0 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-02-20 16:52:00                  |2014-02-28 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2013-12-15T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2013-12-15T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 0
@@ -411,7 +429,10 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b0 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-02-20 16:52:00                  |2014-02-28 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-02-02T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-02-02T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -468,7 +489,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-23T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -530,7 +554,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-23T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -591,7 +618,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-23T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-23T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -658,7 +688,10 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-05 16:52:00                  |2014-01-10 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-15T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-15T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -724,7 +757,10 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-15 16:52:00                  |2014-02-05 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-17T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -783,7 +819,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-17T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -848,7 +887,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-17T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -936,7 +978,10 @@ Feature: traffic report api
         | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-17T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 1
@@ -1044,7 +1089,10 @@ Feature: traffic report api
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
         | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-10 16:52:00                  |2014-01-20 16:52:00 |
 
-    When I get "/traffic_reports?current_time=2014-01-17T23:52:12Z"
+    When I post to "/traffic_reports" with:
+    """
+    {"current_time": "2014-01-17T23:52:12Z"}
+    """
     Then the status code should be "200"
     And the header "Content-Type" should be "application/json"
     And the field "disruptions" should have a size of 2
@@ -1102,7 +1150,10 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:53:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-21T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 2
         And the field "traffic_reports" should have a size of 2
@@ -1166,7 +1217,10 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab232-3d47-4eea-aa2c-22f8680230b3 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-21T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 4
         And the field "traffic_reports" should have a size of 1
@@ -1243,7 +1297,10 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-21T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 6
         And the field "traffic_reports" should have a size of 1
@@ -1314,7 +1371,10 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z"
+        When I post to "/traffic_reports" with:
+        """
+        {"current_time": "2014-01-21T23:52:12Z"}
+        """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 5
         And the field "traffic_reports" should have a size of 1
@@ -1362,9 +1422,9 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 1
@@ -1413,9 +1473,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 0
@@ -1459,9 +1519,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 2
@@ -1524,9 +1584,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:53:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 1

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -7,7 +7,7 @@ DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'))
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
-NAVITIA_TIMEOUT = 5
+NAVITIA_TIMEOUT = 10
 
 
 DEBUG = True

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -7,6 +7,7 @@ DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'))
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
+NAVITIA_TIMEOUT = 5
 
 
 DEBUG = True


### PR DESCRIPTION
# Description

This PR change the filter on traffic_report to a POST filter

## Issue

Issue link: BOT-503

## How to test

Here are the following steps to test this pull request:

- Create disruptions on chaos
- Post to traffic_report API with correct filter : 
```
{"ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
```
