### PR TITLE
Feature bot 499 filter on traffic reports

### DIFF
--- a/chaos/default_settings.py
+++ b/chaos/default_settings.py
@@ -7,6 +7,7 @@ SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql:/
 DEBUG = (os.getenv('DEBUG', 1) == 1)
 
 NAVITIA_URL = str(os.getenv('NAVITIA_URL', 'http://navitia2-ws.ctp.dev.canaltp.fr'))
+NAVITIA_TIMEOUT = os.getenv('NAVITIA_TIMEOUT', 1)
 
 # rabbitmq connections string: http://kombu.readthedocs.org/en/latest/userguide/connections.html#urls
 RABBITMQ_CONNECTION_STRING = str(

--- a/chaos/navitia.py
+++ b/chaos/navitia.py
@@ -37,7 +37,7 @@ __all__ = ['Navitia']
 
 
 class Navitia(object):
-    def __init__(self, url, coverage, token=None, timeout=1):
+    def __init__(self, url, coverage, token=None, timeout=app.config['NAVITIA_TIMEOUT']):
         self.url = url
         self.coverage = coverage
         self.token = token

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -996,15 +996,28 @@ class TrafficReport(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     def get(self, contributor, navitia):
+        return self._get_traffic_report(contributor.id, navitia)
+
+    @validate_contributor()
+    @validate_navitia()
+    @manage_navitia_error()
+    @validate_client_token()
+    def post(self, contributor, navitia):
+        return self._get_traffic_report(contributor.id, navitia, request.get_json(silent=True))
+
+    def _get_traffic_report(self, contributor_id, navitia, body_json=None):
         self.navitia = navitia
         args = self.parsers['get'].parse_args()
-        body = (json.loads(request.data) if request.data else None)
-        g.current_time = args['current_time']
-        disruptions = models.Disruption.traffic_report_filter(contributor.id)
+        if body_json is None:
+            body_json = {}
+        g.current_time = (utils.get_datetime(body_json.get('current_time'), 'current_time')
+                          if body_json.get('current_time')
+                          else args['current_time'])
+        disruptions = models.Disruption.traffic_report_filter(contributor_id)
 
         # Filter disruptions by PtObject
-        if body and body.get('ptObjectFilter', []):
-            utils.filter_disruptions_by_ptobjects(disruptions, body['ptObjectFilter'])
+        if body_json.get('ptObjectFilter', []):
+            utils.filter_disruptions_by_ptobjects(disruptions, body_json['ptObjectFilter'])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []
@@ -1026,7 +1039,6 @@ class TrafficReport(flask_restful.Resource):
             },
             traffic_reports_marshaler
         ), 200
-
 
 class Property(flask_restful.Resource):
     def __init__(self):

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -943,12 +943,44 @@
               $ref: "#/definitions/error_404"
     /traffic_reports:
       get:
+        deprecated: true
         description: This service provides the state of public transport traffic
         parameters:
         - $ref: "#/parameters/header_authorization"
         - $ref: "#/parameters/header_coverage"
         - $ref: "#/parameters/header_customer_id"
         - $ref: "#/parameters/header_contributors"
+        tags:
+          - Traffic Report
+        responses:
+          200:
+            description: State of public transport traffic
+            schema:
+              type: object
+              properties:
+                disruptions:
+                  type: array
+                  items:
+                    $ref: "#/definitions/traffic_report_disruption"
+                traffic_reports:
+                  type: array
+                  items:
+                    $ref: "#/definitions/traffic_report"
+      post:
+        description: This service provides the state of public transport traffic with filter
+        parameters:
+        - $ref: "#/parameters/header_authorization"
+        - $ref: "#/parameters/header_coverage"
+        - $ref: "#/parameters/header_customer_id"
+        - $ref: "#/parameters/header_contributors"
+        - in: body
+          name: body
+          description: Filter only disruption with this PtObject list
+          schema:
+            type: object
+            properties:
+              ptObjectFilter:
+                $ref: "#/definitions/traffic_report_pt_object_filter"
         tags:
           - Traffic Report
         responses:
@@ -1821,6 +1853,29 @@
                 type: "array"
                 items:
                   type: "string"
+    traffic_report_pt_object_filter:
+      type: "object"
+      properties:
+        networks:
+          type: "array"
+          items:
+            description: "Id of network object"
+            type: "string"
+        lines:
+          type: "array"
+          items:
+            description: "Id of line object"
+            type: "string"
+        stop_points:
+          type: "array"
+          items:
+            description: "Id of stop_point object"
+            type: "string"
+        stop_areas:
+          type: "array"
+          items:
+            description: "Id of stop_area object"
+            type: "string"
     traffic_report_disruption:
       type: "object"
       properties:

--- a/tests/features/traffic_reports.feature
+++ b/tests/features/traffic_reports.feature
@@ -1362,9 +1362,9 @@ Feature: traffic report api
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 1
@@ -1413,9 +1413,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 0
@@ -1459,9 +1459,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 2
@@ -1524,9 +1524,9 @@ Feature: traffic report api
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-01-20 16:53:00                  |2014-01-30 16:52:00 |
 
-        When I get "/traffic_reports?current_time=2014-01-21T23:52:12Z" with:
+        When I post to "/traffic_reports" with:
         """
-        {"ptObjectFilter": {"networks": ["network:JDR:2"]}}
+        {"current_time": "2014-01-21T23:52:12Z", "ptObjectFilter": {"networks": ["network:JDR:2"]}}
         """
         Then the status code should be "200"
         And the field "disruptions" should have a size of 1

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -7,6 +7,7 @@ DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'))
 
 NAVITIA_URL = 'http://navitia2-ws.ctp.customer.canaltp.fr/'
+NAVITIA_TIMEOUT = 10
 
 
 DEBUG = True


### PR DESCRIPTION
# Description

This PR change the filter on traffic_report to a POST filter

## Issue

Issue link: BOT-503

## How to test

Here are the following steps to test this pull request:

- Create disruptions on chaos
- Post to traffic_report API with correct filter : 
```
{"ptObjectFilter": {"networks": ["network:JDR:2"], "lines": ["line:JDR:TGV"]}}
```
