### PR TITLE
Add networks filter management

### DIFF
--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1015,9 +1015,11 @@ class TrafficReport(flask_restful.Resource):
                           else args['current_time'])
         disruptions = models.Disruption.traffic_report_filter(contributor_id)
 
+        networks_filter = []
         # Filter disruptions by PtObject
         if body_json.get('ptObjectFilter', []):
             utils.filter_disruptions_by_ptobjects(disruptions, body_json['ptObjectFilter'])
+            networks_filter = body_json['ptObjectFilter'].get('networks', [])
 
         # Prepare line sections to get them all in once
         pt_object_ids = []
@@ -1031,7 +1033,7 @@ class TrafficReport(flask_restful.Resource):
         for line_section in line_sections:
             line_sections_by_objid[line_section.object_id] = line_section
 
-        result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid)
+        result = utils.get_traffic_report_objects(disruptions, self.navitia, line_sections_by_objid, networks_filter)
         return marshal(
             {
                 'traffic_reports': [value for key, value in result["traffic_report"].items()],

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -489,7 +489,7 @@ def get_navitia_networks(result, pt_object, navitia, types):
     return networks
 
 
-def manage_other_object(result, impact, pt_object, navitia, types, line_sections_by_objid):
+def manage_other_object(result, impact, pt_object, navitia, types, line_sections_by_objid, networks_filter):
 
     navitia_type = types
     pt_object_for_navitia_research = pt_object
@@ -502,6 +502,8 @@ def manage_other_object(result, impact, pt_object, navitia, types, line_sections
     if navitia_networks:
         for network in navitia_networks:
             if 'id' in network and network['id'] not in result["traffic_report"]:
+                if networks_filter and network['id'] not in networks_filter:
+                    continue
                 add_network(result, network, False)
                 result["traffic_report"][network['id']][types] = []
 
@@ -567,7 +569,7 @@ def create_line_section(navitia_object, line_section_obj):
     return line_section
 
 
-def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid):
+def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid, networks_filter):
     """
     :param impacts: Sequence of impact (Database object)
     :return: dict
@@ -616,7 +618,7 @@ def get_traffic_report_objects(disruptions, navitia, line_sections_by_objid):
                             )
                             continue
                         manage_other_object(result, impact, pt_object, navitia, collections[pt_object.type],
-                                            line_sections_by_objid)
+                                            line_sections_by_objid, networks_filter)
 
     return result
 

--- a/tests/traffic_reports_test.py
+++ b/tests/traffic_reports_test.py
@@ -209,6 +209,32 @@ def test_get_traffic_report_with_impact_on_stop_areas_one_network():
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
+def test_get_traffic_report_with_impact_on_stop_areas_2_networks_and_filter_activated():
+    navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
+    navitia.get_pt_object = get_pt_object
+    disruption = chaos.models.Disruption()
+    impact = chaos.models.Impact()
+    impact.status = 'published'
+
+    line = chaos.models.PTobject()
+    line.type = 'stop_area'
+    line.uri = 'stop_area:uri2'
+    impact.objects.append(line)
+    disruption.impacts.append(impact)
+
+    result = {
+        "network:uri5": {
+            "network": {
+                "id": "network:uri5",
+                "name": "network 5 name"
+            },
+            "stop_areas": [{'id': 'stop_area:uri2', 'name': 'stop area 2 name', "impacts": [impact]}]
+        }
+    }
+    dd = get_traffic_report_objects([disruption], navitia, {}, ["network:uri5"])
+    eq_(cmp(dd["traffic_report"], result), 0)
+
+
 def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
     navitia = chaos.navitia.Navitia('http://api.navitia.io', 'jdr')
     navitia.get_pt_object = get_pt_object

--- a/tests/traffic_reports_test.py
+++ b/tests/traffic_reports_test.py
@@ -9,13 +9,13 @@ class Obj(object):
 
 
 def test_get_traffic_report_objects():
-    dd = get_traffic_report_objects([], Obj(), {})
+    dd = get_traffic_report_objects([], Obj(), {}, [])
     eq_(len(dd["traffic_report"].items()), 0)
 
 
 def test_get_traffic_report_without_objects():
     disruption = chaos.models.Disruption()
-    dd = get_traffic_report_objects([disruption], Obj(), {})
+    dd = get_traffic_report_objects([disruption], Obj(), {}, [])
     eq_(len(dd["traffic_report"].items()), 0)
 
 
@@ -63,7 +63,7 @@ def test_get_traffic_report_with_network():
             }
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, {})
+    dd = get_traffic_report_objects([disruption], navitia, {}, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -140,7 +140,7 @@ def test_get_traffic_report_with_impact_on_lines():
             "lines": [{'id': 'line:uri2', 'name': 'line 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, {})
+    dd = get_traffic_report_objects([disruption], navitia, {}, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -178,7 +178,7 @@ def test_get_traffic_report_with_impact_on_networks():
             }
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, {})
+    dd = get_traffic_report_objects([disruption], navitia, {}, [])
 
     eq_(cmp(dd["traffic_report"], result), 0)
 
@@ -205,7 +205,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_one_network():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, {})
+    dd = get_traffic_report_objects([disruption], navitia, {}, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -238,7 +238,7 @@ def test_get_traffic_report_with_impact_on_stop_areas_2_networks():
             "stop_areas": [{'id': 'stop_area:uri2', 'name': 'stop area 2 name', "impacts": [impact]}]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, {})
+    dd = get_traffic_report_objects([disruption], navitia, {}, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -279,7 +279,7 @@ def test_get_traffic_report_with_2_impact_on_stop_area():
             "stop_areas": [{'id': 'stop_area:uri1', 'name': 'stop area 1 name', "impacts": impacts}]
         }
     }
-    dd = get_traffic_report_objects(disruptions, navitia, {})
+    dd = get_traffic_report_objects(disruptions, navitia, {}, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 
@@ -346,7 +346,7 @@ def test_get_traffic_report_with_impact_on_line_sections():
             ]
         }
     }
-    dd = get_traffic_report_objects([disruption], navitia, { ptobject.id: ptobject.line_section })
+    dd = get_traffic_report_objects([disruption], navitia, { ptobject.id: ptobject.line_section }, [])
     eq_(cmp(dd["traffic_report"], result), 0)
 
 def test_filter_disruptions_by_ptobjects():


### PR DESCRIPTION
# Description

This PR fixes the problem of having multiple networks in global view on stop area impact when permission is on one networks

## Issue

Issue link: BOT-555

