### PR TITLE
Format DateTime now to second

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -31,7 +31,7 @@
 
 import uuid
 from chaos import db, utils, exceptions
-from utils import paginate, get_current_time
+from utils import paginate, get_current_time, get_current_time_format_second
 from sqlalchemy.dialects.postgresql import UUID, BIT
 from datetime import datetime
 from formats import publication_status_values
@@ -51,13 +51,13 @@ def set_utc_on_connect(dbapi_con, connection_record, connection_proxy):
 class TimestampMixin(object):
     created_at = db.Column(
         db.DateTime(),
-        default=datetime.utcnow,
+        default=get_current_time_format_second,
         nullable=False
     )
     updated_at = db.Column(
         db.DateTime(),
         default=None,
-        onupdate=datetime.utcnow
+        onupdate=get_current_time_format_second
     )
 
 

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -31,7 +31,7 @@
 
 import uuid
 from chaos import db, utils, exceptions
-from utils import paginate, get_current_time, get_current_time_format_second
+from utils import paginate, get_current_time
 from sqlalchemy.dialects.postgresql import UUID, BIT
 from datetime import datetime
 from formats import publication_status_values
@@ -51,13 +51,13 @@ def set_utc_on_connect(dbapi_con, connection_record, connection_proxy):
 class TimestampMixin(object):
     created_at = db.Column(
         db.DateTime(),
-        default=get_current_time_format_second,
+        default=get_current_time,
         nullable=False
     )
     updated_at = db.Column(
         db.DateTime(),
         default=None,
-        onupdate=get_current_time_format_second
+        onupdate=get_current_time
     )
 
 

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -179,11 +179,18 @@ def get_utc_datetime_by_zone(value, time_zone):
 def get_current_time():
     """
         Get current time global variable
-        :return: DateTime format '2014-04-31T16:52:00'
+        :return: DateTime format '2014-04-31T16:52:00.000000'
     """
     if 'current_time' in g and g.current_time:
         return g.current_time
     return datetime.utcnow()
+
+def get_current_time_format_second():
+    """
+        Get DateTime formatted to second
+        :return: DateTime format '2018-04-31T16:52:00'
+    """
+    return datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S");
 
 
 def option_value(values):

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -179,19 +179,11 @@ def get_utc_datetime_by_zone(value, time_zone):
 def get_current_time():
     """
         Get current time global variable
-        :return: DateTime format '2014-04-31T16:52:00.000000'
+        :return: DateTime format '2014-04-31T16:52:00'
     """
     if 'current_time' in g and g.current_time:
         return g.current_time
-    return datetime.utcnow()
-
-def get_current_time_format_second():
-    """
-        Get DateTime formatted to second
-        :return: DateTime format '2018-04-31T16:52:00'
-    """
-    return datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S");
-
+    return datetime.utcnow().replace(microsecond=0)
 
 def option_value(values):
     def to_return(value, name):

--- a/tests/current_time_test.py
+++ b/tests/current_time_test.py
@@ -11,14 +11,14 @@ def test_current_time():
         eq_(chaos.utils.get_current_time(), g.current_time)
 
 
-#current_time is exists in g and g.current_time None
+#current_time exists in g and g.current_time None
 def test_now_current_time1():
     with chaos.app.app_context():
         g.current_time = None
-        eq_(datetime.utcnow() < chaos.utils.get_current_time(), True)
+        eq_(datetime.utcnow().replace(microsecond=0), chaos.utils.get_current_time())
 
 
-#current_time is not exists
+#current_time doesn't exists
 def test_now_current_time2():
     with chaos.app.app_context():
-        eq_(datetime.utcnow() < chaos.utils.get_current_time(), True)
+        eq_(datetime.utcnow().replace(microsecond=0), chaos.utils.get_current_time())

--- a/tests/features/steps.py
+++ b/tests/features/steps.py
@@ -181,7 +181,7 @@ def and_in_the_json_the_field_is_an_id(step, fields):
 
 @step(u'And in the database for the (\w+) "([^"]+)" the field "([^"]*)" should be "([^"]*)"')
 def and_in_the_database_the_severity_group1_the_field_group2_should_be_group3(step, cls, id, field, value):
-    #this way flask manage the sqlalchemy session
+    #Context to allow Flask to manage sqlalchemy session
     with chaos.app.app_context():
         row = model_classes[cls].query.filter_by(id=id).first()
         eq_(getattr(row, field), pythonify(value))
@@ -189,14 +189,16 @@ def and_in_the_database_the_severity_group1_the_field_group2_should_be_group3(st
 
 @step(u'Given I have the following (\w+) in my database:')
 def given_i_have_the_following_causes_in_my_database(step, cls):
-    for values_dict in step.hashes:
-        row = model_classes[cls]()
-        for key, value in values_dict.iteritems():
-            if value == 'None':
-                value = None
-            setattr(row, key, value)
-        db.session.add(row)
-    db.session.commit()
+    # Context to allow Flask to manage sqlalchemy session
+    with chaos.app.app_context():
+        for values_dict in step.hashes:
+            row = model_classes[cls]()
+            for key, value in values_dict.iteritems():
+                if value == 'None':
+                    value = None
+                setattr(row, key, value)
+            db.session.add(row)
+        db.session.commit()
 
 @step(u'Given I have the relation (\w+) in my database:')
 def given_i_have_the_relation_in_my_database(step, cls):
@@ -243,7 +245,7 @@ def and_the_field_group1_is_valid_impact(step, group1):
 @step(u'And the field "([^"]*)" should have "([^"]*)" with "(.*)"')
 def and_the_field_group1_should_have_obj_with_group2(step, source_field, search_field, group2):
     import json
-    #search attribut keys
+    #search attribute keys
     group2_json = json.loads(group2)
     group2_keys = set(group2_json.keys())
     exists = False

--- a/tests/publication_status_test.py
+++ b/tests/publication_status_test.py
@@ -6,7 +6,7 @@ import chaos
 def test_publication_status_past():
     with chaos.app.app_context():
         ob = chaos.models.Disruption()
-        now = datetime.utcnow()
+        now = chaos.utils.get_current_time()
         ob.start_publication_date = now + timedelta(days=-4)
         ob.end_publication_date = now + timedelta(days=-1)
         eq_(ob.publication_status,  'past')
@@ -23,20 +23,20 @@ def test_publication_status_ongoing():
 def test_publication_status_coming():
     with chaos.app.app_context():
         ob = chaos.models.Disruption()
-        ob.start_publication_date = datetime.utcnow() + timedelta(days=1)
+        ob.start_publication_date = chaos.utils.get_current_time() + timedelta(days=1)
         ob.end_publication_date = ob.start_publication_date + timedelta(days=3)
         eq_(ob.publication_status,  'coming')
 
 def test_publication_status_coming_not_end_publication_date():
     with chaos.app.app_context():
         ob = chaos.models.Disruption()
-        ob.start_publication_date = datetime.utcnow() + timedelta(days=1)
+        ob.start_publication_date = chaos.utils.get_current_time() + timedelta(days=1)
         ob.end_publication_date = None
         eq_(ob.publication_status,  'coming')
 
 def test_publication_status_ongoing_not_end_publication_date():
     with chaos.app.app_context():
         ob = chaos.models.Disruption()
-        ob.start_publication_date = datetime.utcnow() + timedelta(days=-1)
+        ob.start_publication_date = chaos.utils.get_current_time() + timedelta(days=-1)
         ob.end_publication_date = None
         eq_(ob.publication_status,  'ongoing')

--- a/tests/publication_status_test.py
+++ b/tests/publication_status_test.py
@@ -15,7 +15,7 @@ def test_publication_status_past():
 def test_publication_status_ongoing():
     with chaos.app.app_context():
         ob = chaos.models.Disruption()
-        ob.start_publication_date = datetime.utcnow()
+        ob.start_publication_date = chaos.utils.get_current_time()
         ob.end_publication_date = ob.start_publication_date + timedelta(days=2)
         eq_(ob.publication_status,  'ongoing')
 

--- a/tests/testing_settings.py
+++ b/tests/testing_settings.py
@@ -1,7 +1,7 @@
 import os
 
 #URI for postgresql
-# postgresql://<user>:<password>@<host>:<port>/<dbname>
+#postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 DATABASE_HOST = str(os.getenv('DATABASE_HOST', 'localhost'))
 SQLALCHEMY_DATABASE_URI = str(os.getenv('SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@' + DATABASE_HOST + '/chaos_testing'))
@@ -16,11 +16,11 @@ RABBITMQ_HOST = str(os.getenv('RABBITMQ_HOST', 'localhost'))
 RABBITMQ_CONNECTION_STRING = 'pyamqp://guest:guest@' + RABBITMQ_HOST + ':5672//?heartbeat=60'
 
 
-#amqp exhange used for sending disruptions
+#amqp exchange used for sending disruptions
 EXCHANGE='navitia'
 
 CONTRIBUTOR='shortterm.tn'
-#
+
 ENABLE_RABBITMQ=False
 
 CACHE_CONFIGURATION = {


### PR DESCRIPTION
# Description

This PR fixes difference in Datetime rendered value between a 
- nominal case : disruption/impact values passing via RMQ to Navitia (it doesn't round datetime second value)
- Navitia reinit case : disruption/impact values directly read in Chaos DB (it rounds datetime to closest second)

## Issue (optional)

Issue link: BOT-569

## Pull Request type (optional)

bug fix

## How to test

- Submit a disruption to Navitia and compare  'created_at' recorded in DB Chaos and 'updated_at' in Navitia
- Stop and restart Navitia to reload disruptions, and compare  'created_at' recorded in DB Chaos and 'updated_at' in Navitia

It should always be the same