### PR TITLE
Add filter on category

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -499,7 +499,8 @@ class Disruption(TimestampMixin, db.Model):
             uri,
             line_section,
             statuses,
-            query=None):
+            query=None,
+            cause_category_id=None):
         availlable_filters = {
             'past': and_(cls.end_publication_date != None, cls.end_publication_date < get_current_time()),
             'ongoing': and_(cls.start_publication_date <= get_current_time(),
@@ -514,6 +515,10 @@ class Disruption(TimestampMixin, db.Model):
             cls.contributor_id == contributor_id,
             cls.status.in_(statuses)
         ))
+
+        if cause_category_id:
+            query = query.join(cls.cause)
+            query = query.filter(Cause.category_id == cause_category_id)
 
         if ends_after_date:
             query = query.filter(cls.end_publication_date >= ends_after_date)
@@ -566,7 +571,8 @@ class Disruption(TimestampMixin, db.Model):
             uri,
             line_section,
             statuses,
-            ptObjectFilter):
+            ptObjectFilter,
+            cause_category_id):
         query = cls.query
         object_types = []
         uris = []
@@ -606,7 +612,8 @@ class Disruption(TimestampMixin, db.Model):
             uri=uri,
             line_section=line_section,
             statuses=statuses,
-            query=query
+            query=query,
+            cause_category_id=cause_category_id
         )
 
     @classmethod

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -491,7 +491,8 @@ class DisruptionsSearch(flask_restful.Resource):
             uri=args['uri'],
             line_section=args['line_section'],
             statuses=json.get('status', disruption_status_values),
-            ptObjectFilter=json.get('ptObjectFilter', None)
+            ptObjectFilter=json.get('ptObjectFilter', None),
+            cause_category_id=json.get('cause_category_id', None)
         )
         response = {'disruptions': result.items, 'meta': make_pager(result, 'disruption')}
 

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2313,6 +2313,10 @@
           description: With depth=2, you could retrieve the first page of impacts from the disruption
           type: integer
           default: 1
+        cause_category_id:
+          description: Filter by category id
+          type: string
+          format: uuid
         ptObjectFilter:
           $ref: "#/definitions/pt_object_filter"
     impact:

--- a/tests/features/list-disruptions-search-post.feature
+++ b/tests/features/list-disruptions-search-post.feature
@@ -621,7 +621,7 @@ Feature: list disruptions with ptObjects filter
 
         Given I have the following causes in my database:
             | wording   |  created_at          | updated_at          | is_visible | category_id                          | id                                   | client_id                            |
-            | weather   |  2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | weather   |  2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab234-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
             | strike    |  2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
             | nuke      |  2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab231-3d48-4eea-aa2c-22f8680230b6 | 7ffab233-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
@@ -633,11 +633,12 @@ Feature: list disruptions with ptObjects filter
             | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
             | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffac230-3d48-4eea-aa2c-22f8680230b6 | 7ffab233-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
             | bar       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+            | bar       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 3ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab234-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
 
         Given I have the following impacts in my database:
             | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                          |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 3ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eec-aa2c-22f8680230b7 | 7ffac230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
 
         Given I have the following ptobject in my database:

--- a/tests/features/list-disruptions-search-post.feature
+++ b/tests/features/list-disruptions-search-post.feature
@@ -604,3 +604,69 @@ Feature: list disruptions with ptObjects filter
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
+
+    Scenario: Filter on category
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following categories in my database:
+            | name      | note  | created_at          | updated_at          | id                                   | client_id                            |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | goo       | helio | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab231-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   |  created_at          | updated_at          | is_visible | category_id                          | id                                   | client_id                            |
+            | weather   |  2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | strike    |  2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | nuke      |  2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab231-3d48-4eea-aa2c-22f8680230b6 | 7ffab233-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b7 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffac230-3d48-4eea-aa2c-22f8680230b6 | 7ffab233-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+            | bar       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 2ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eec-aa2c-22f8680230b7 | 7ffac230-3d48-4eea-aa2c-22f8680230b6 | 7ffab232-3d48-4eea-aa2c-22f8680230b7 |
+
+        Given I have the following ptobject in my database:
+            | type      | uri                    | created_at          | updated_at          | id                                         |
+            | stop_area | stop_area:JDR:SA:CHVIN | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b6       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                               | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab234-3d49-4eea-aa2c-22f8680230b3 |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab234-3d49-4eec-aa2c-22f8680230b7 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            | start_date           | end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 2014-04-10 16:52:00  | 2014-04-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 2014-04-10 16:52:00  | 2014-04-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b8 | 7ffab234-3d49-4eec-aa2c-22f8680230b7 | 2014-04-10 16:52:00  | 2014-04-30 16:52:00 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "cause_category_id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "cause_category_id": "7ffab231-3d48-4eea-aa2c-22f8680230b6"}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1


### PR DESCRIPTION
# Description

This PR add category filter to `disruptions/_search` api

## Issue

Issue link: BOT-788

## How to test

Here are the following steps to test this pull request:

- create disruptions with different category
- use api  `disruptions/_search` with parameter `cause_category_id` in the POST request
- this should filter the response


Documentation : http://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/task-bot-788-add-filter-on-category/documentation/swagger.yml

