### PR TITLE
disruptions_search_example_start_page_1_instead_0

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2251,6 +2251,7 @@
           type: integer
           default: 1
           minimum: 1
+          example: 1
         items_per_page:
           description: Number of items per page
           type: integer


### PR DESCRIPTION
# Description

The given _search example had "start_page":0, when the minimum is 1.

