### PR TITLE
Add 'disable_disruption' to queries

### DIFF
--- a/chaos/navitia.py
+++ b/chaos/navitia.py
@@ -65,7 +65,7 @@ class Navitia(object):
             url=self.url, coverage=self.coverage, collection=self.collections[object_type], uri=uri)
         if pt_objects:
             query = '{q}/{objects}'.format(q=query, objects=pt_objects)
-        return query + '?depth=0'
+        return query + '?depth=0&disable_disruption=true'
 
     @retry(retry_on_exception=lambda e: isinstance(e, requests.exceptions.Timeout),
            stop_max_attempt_number=3, wait_fixed=100)

--- a/tests/navitia_test.py
+++ b/tests/navitia_test.py
@@ -41,7 +41,7 @@ def navitia_mock_unknown_object_type(url, request):
 def test_get_pt_object():
     n = Navitia('http://api.navitia.io', 'jdr')
     mock = NavitiaMock(200, {'networks': [{'id': 'network:foo', 'name': 'reseau foo'}]},
-                       assert_url='http://api.navitia.io/v1/coverage/jdr/networks/network:foo?depth=0')
+                       assert_url='http://api.navitia.io/v1/coverage/jdr/networks/network:foo?depth=0&disable_disruption=true')
     with HTTMock(mock):
         eq_(n.get_pt_object('network:foo', 'network'), {'id': 'network:foo', 'name': 'reseau foo'})
 
@@ -70,7 +70,7 @@ def test_navitia_unknown_object_type():
 
 def test_query_formater():
     n = Navitia('http://api.navitia.io', 'jdr')
-    eq_(n.query_formater('uri', 'network'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri?depth=0')
+    eq_(n.query_formater('uri', 'network'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri?depth=0&disable_disruption=true')
 
 
 def test_query_formater_line_section():
@@ -80,13 +80,13 @@ def test_query_formater_line_section():
 
 def test_query_formater_all():
     n = Navitia('http://api.navitia.io', 'jdr')
-    eq_(n.query_formater('uri', 'network', 'networks'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri/networks?depth=0')
+    eq_(n.query_formater('uri', 'network', 'networks'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri/networks?depth=0&disable_disruption=true')
 
 
 @raises(exceptions.ObjectTypeUnknown)
 def test_query_formater_all_objects_invalid():
     n = Navitia('http://api.navitia.io', 'jdr')
-    eq_(n.query_formater('uri', 'network', 'stop_areas'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri/networks?depth=0')
+    eq_(n.query_formater('uri', 'network', 'stop_areas'), 'http://api.navitia.io/v1/coverage/jdr/networks/uri/networks?depth=0&disable_disruption=true')
 
 
 navitia_timeout_count = 0


### PR DESCRIPTION
# Description

This PR fixes possible Navitia timeouts

## Issue (optional)

Issue link: BOT-791

## How to test

Here are the following steps to test this pull request:
- simulate numerous disruptions on the same ptObject
- try to display 'dashboard ' page in TR ihm for this client
- it had to display something (instead of blank)


Relates to Navitia upgrade https://github.com/CanalTP/navitia/releases/tag/v2.63.0 disable_disruption feature