### PR TITLE
Add example in doc for publication_status

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1367,7 +1367,7 @@
     publication_status:
       in: query
       name: publication_status
-      description: Filter by publication_status
+      description: Filter by publication_status (example:publication_status[]=ongoing)
       required: false
       default:
         - past


### PR DESCRIPTION
# Description

This PR adds a little example for `publication_status`

## Issue (optional)

Issue link: BOT-806

## Pull Request type (optional)

When doing the BOT-806 ticket, we found that it is not very obvious to understand how to use the `publication_status` filter, so I add a little example in the documentation