### PR TITLE
Required channels

### DIFF
--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -239,9 +239,9 @@ def manage_channels_required(messages_json, client_id):
     if channels_required:
         for channel_required in channels_required:
             if channel_required.id not in messages_json or messages_json[channel_required.id] is None:
-                raise exceptions.InvalidJson('Required channel {}'.format(channel_required.id))
+                raise exceptions.InvalidJson('Channel {} is required.'.format(channel_required.id))
             elif not messages_json[channel_required.id]['text']:
-                raise exceptions.InvalidJson('Text for required channel {} is empty'.format(channel_required.id))
+                raise exceptions.InvalidJson('Empty property \'text\' is not allowed for channel {}.'.format(channel_required.id))
 
 def manage_message_meta(message, json):
     meta_db = dict((meta.key, meta) for meta in message.meta)

--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -211,11 +211,12 @@ def fill_and_add_line_section(navitia, impact_id, all_objects, pt_object_json):
     return ptobject
 
 
-def manage_message(impact, json):
+def manage_message(impact, json, client_id):
     messages_db = dict((msg.channel_id, msg) for msg in impact.messages)
     messages_json = dict()
     if 'messages' in json:
         messages_json = dict((msg["channel"]["id"], msg) for msg in json['messages'])
+        manage_channels_required(messages_json, client_id)
         for message_json in json['messages']:
             if message_json["channel"]["id"] in messages_db:
                 msg = messages_db[message_json["channel"]["id"]]
@@ -232,6 +233,15 @@ def manage_message(impact, json):
     difference = set(messages_db) - set(messages_json)
     for diff in difference:
         impact.delete_message(messages_db[diff])
+
+def manage_channels_required(messages_json, client_id):
+    channels_required = models.Channel.get_channels_required(client_id)
+    if channels_required:
+        for channel_required in channels_required:
+            if channel_required.id not in messages_json or messages_json[channel_required.id] is None:
+                raise exceptions.InvalidJson('Required channel {}'.format(channel_required.id))
+            elif not messages_json[channel_required.id]['text']:
+                raise exceptions.InvalidJson('Text for required channel {} is empty'.format(channel_required.id))
 
 def manage_message_meta(message, json):
     meta_db = dict((meta.key, meta) for meta in message.meta)
@@ -325,7 +335,7 @@ def create_or_update_impact(disruption, json_impact, navitia, impact_id=None):
     # or from apllication_periods in the data json
     app_periods_by_pattern = get_application_periods(json_impact)
     manage_application_periods(impact_bd, app_periods_by_pattern)
-    manage_message(impact_bd, json_impact)
+    manage_message(impact_bd, json_impact, disruption.client.id)
 
     return impact_bd
 

--- a/chaos/fields.py
+++ b/chaos/fields.py
@@ -401,6 +401,7 @@ base_channel_fields = {
     'name': fields.Raw,
     'max_size': fields.Integer(default=None),
     'content_type': fields.Raw,
+    'required': fields.Raw,
     'types': FieldChannelTypes()
 }
 

--- a/chaos/formats.py
+++ b/chaos/formats.py
@@ -241,6 +241,7 @@ channel_input_format = {
         'name': {'type': 'string', 'maxLength': 250},
         'max_size': {'type': ['integer', 'null']},
         'content_type': {'type': 'string', 'maxLength': 250},
+        'required': {'type': 'boolean'},
         'types': {
             'type': 'array',
             'items': channel_type_input_format,

--- a/chaos/mapper.py
+++ b/chaos/mapper.py
@@ -85,7 +85,7 @@ class OptionalField(object):
         self.attribute = attribute
 
     def __call__(self, item, field, json):
-        if field in json and json[field]:
+        if field in json and json[field] is not None:
             setattr(item, self.attribute, json[field])
 
 
@@ -167,7 +167,8 @@ application_period_mapping = {
 channel_mapping = {
     'name': None,
     'max_size': None,
-    'content_type': None
+    'content_type': None,
+    'required': OptionalField(attribute='required')
 }
 
 line_section_mapping = {

--- a/chaos/mapper.py
+++ b/chaos/mapper.py
@@ -27,8 +27,8 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from aniso8601 import parse_datetime, parse_time, parse_date
 from collections import Mapping, Sequence
+from aniso8601 import parse_datetime, parse_time, parse_date
 
 
 class Datetime(object):

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -490,7 +490,8 @@ class Disruption(TimestampMixin, db.Model):
         ).first_or_404()
 
     @classmethod
-    def get_query_with_args(cls,
+    def get_query_with_args(
+            cls,
             contributor_id,
             publication_status,
             ends_after_date,

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -974,6 +974,10 @@ class Channel(TimestampMixin, db.Model):
     def get(cls, id, client_id):
         return cls.query.filter_by(id=id, client_id=client_id, is_visible=True).first_or_404()
 
+    @classmethod
+    def get_channels_required(cls, client_id):
+        return cls.query.filter_by(client_id=client_id, is_visible=True, required=True).all()
+
 associate_message_meta = db.Table(
     'associate_message_meta',
     db.metadata,

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -940,6 +940,7 @@ class Channel(TimestampMixin, db.Model):
     client_id = db.Column(UUID, db.ForeignKey(Client.id), nullable=False)
     client = db.relationship('Client', backref='channels')
     channel_types = db.relationship('ChannelType', backref='channel', lazy='joined')
+    required = db.Column(db.Boolean, unique=False, nullable=False, default=False)
 
     def __init__(self):
         self.id = str(uuid.uuid1())

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -318,6 +318,10 @@ class Disruptions(flask_restful.Resource):
             response = self.get_post_error_response_and_log(e, 404)
             return response, 404
 
+        except exceptions.InvalidJson as e:
+            response = self.get_post_error_response_and_log(e, 400)
+            return response, 400
+
         # Add all properties present in Json
         try:
             db_helper.manage_properties(disruption, json)
@@ -326,7 +330,7 @@ class Disruptions(flask_restful.Resource):
             return response, 404
 
         except exceptions.InvalidJson as e:
-            response = self.get_post_error_response_and_log(e, 404)
+            response = self.get_post_error_response_and_log(e, 400)
             return response, 400
 
         try:
@@ -395,8 +399,8 @@ class Disruptions(flask_restful.Resource):
             return response, 404
 
         except exceptions.InvalidJson as e:
-            response = self.get_put_error_response_and_log(e, 404)
-            return response, 404
+            response = self.get_put_error_response_and_log(e, 400)
+            return response, 400
 
         # Add all properties present in Json
         try:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1652,6 +1652,9 @@
           type: "string"
         max_size:
           type: "integer"
+        required:
+          type: "boolean"
+          example: false
         created_at:
           type: "string"
           pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
@@ -1673,6 +1676,9 @@
           type: "integer"
         content_type:
           type: "string"
+        required:
+          type: "boolean"
+          example: false
         types:
           type: "array"
           items:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1669,6 +1669,7 @@
             type: "string"
     channel_creation:
       type: "object"
+      required: ["name", "max_size", "content_type", "types"]
       properties:
         name:
           type: "string"

--- a/migrations/versions/dfe97c5974e3_add_channel_required.py
+++ b/migrations/versions/dfe97c5974e3_add_channel_required.py
@@ -1,0 +1,20 @@
+"""add channel required
+
+Revision ID: dfe97c5974e3
+Revises: 548314a1e5ea
+Create Date: 2018-10-01 14:47:15.224515
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dfe97c5974e3'
+down_revision = '548314a1e5ea'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('channel', sa.Column('required', sa.Boolean(), nullable=False, server_default='false'))
+
+def downgrade():
+    op.drop_column('channel', 'required')

--- a/tests/features/list-channel.feature
+++ b/tests/features/list-channel.feature
@@ -28,9 +28,9 @@ Feature: list channel
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
         Given I have the following channels in my database:
-            | name   | max_size   | created_at          | updated_at          | content_type| id                                   |client_id                            |
-            | short  | 140        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | text/plain  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-            | email  | 520        | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | text/plain  | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | name   | max_size   | created_at          | updated_at          | content_type| id                                   | client_id                            | required
+            | short  | 140        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | text/plain  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | true
+            | email  | 520        | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | text/plain  | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | false
         When I get "/channels"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
@@ -38,6 +38,8 @@ Feature: list channel
         And the field "channels.0.name" should be "email"
         And the field "channels.0.max_size" should be 520
         And the field "channels.0.content_type" should be "text/plain"
+        And the field "channels.0.required" should be "False"
+        And the field "channels.1.required" should be "True"
 
     Scenario: list of four channels sorted by name
         Given I have the following clients in my database:
@@ -82,4 +84,3 @@ Feature: list channel
         And the field "channel.name" should be "email"
         And the field "channel.max_size" should be 520
         And the field "channel.content_type" should be "text/plain"
-

--- a/tests/features/put-channel.feature
+++ b/tests/features/put-channel.feature
@@ -59,18 +59,19 @@ Feature: channel can be deleted
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
         Given I have the following channels in my database:
-            | name   | max_size   | created_at          | updated_at          | content_type| id                                   |client_id                            |
-            | short  | 140        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | text/plain  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-            | email  | 520        | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | text/plain  | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | name   | max_size   | created_at          | updated_at          | content_type| id                                   |client_id                            | required
+            | short  | 140        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | text/plain  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 | False
+            | email  | 520        | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | text/plain  | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 | False
         When I put "/channels/7ffab230-3d48-4eea-aa2c-22f8680230b6" with:
         """
-        {"name": "foo", "max_size": 500, "content_type": "text/type", "types": ["web", "sms"]}
+        {"name": "foo", "max_size": 500, "content_type": "text/type", "types": ["web", "sms"], "required": true}
         """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "channel.name" should be "foo"
         And the field "channel.max_size" should be 500
         And the field "channel.types.1" should be "sms"
+        And the field "channel.required" should be "True"
 
     Scenario: modify of one channel by id invalid
         Given I have the following clients in my database:

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -121,6 +121,12 @@ def test_channels_validation():
     json = {'name': 'short', 'max_size': 200, 'content_type': '', 'types': ['web']}
     validate(json, formats.channel_input_format)
 
+    json = {'name': 'short', 'max_size': 200, 'content_type': '', 'types': ['web'], 'required': True}
+    validate(json, formats.channel_input_format)
+
+    json = {'name': 'short', 'max_size': 200, 'content_type': '', 'types': ['web'], 'required': False}
+    validate(json, formats.channel_input_format)
+
 
 @raises(ValidationError)
 def test_channel_validation_attributs_mandatory():
@@ -139,6 +145,15 @@ def test_channel_types_validation_mandatory():
     json = {'name': 'short', 'max_size': 200, 'content_type': '', 'types': []}
     validate(json, formats.channel_input_format)
 
+@raises(ValidationError)
+def test_channel_validation_attributs_mandatory():
+    json = {'name': 'short', 'max_size': 200}
+    validate(json, formats.channel_input_format)
+
+@raises(ValidationError)
+def test_channel_with_required_not_boolean():
+    json = {'name': 'short', 'max_size': 200, 'content_type': '', 'types': ['web'], 'required': 1}
+    validate(json, formats.channel_input_format)
 
 def test_validate_object_format():
     Draft4Validator.check_schema(formats.object_input_format)
@@ -612,6 +627,3 @@ def test_impact_with_notification_date_and_None_value():
 def test_impact_with_notification_date_without_value():
     json = {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"notification_date": "","objects": [{"id": "network:JDR:1", "type": "network"}]}
     validate(json, formats.impact_input_format)
-
-
-


### PR DESCRIPTION
# Description

This PR add the required parameter on the channel type, in order to forbidden impact without specific text (not null or empty) for a channel type. 

## Issue

Issue link: BOT-850

## How to test

Here are the following steps to test this pull request:

- create or update a channel for a client with the new parameter `required` to `true`
- try to create an impact without this channel
