### PR TITLE
Example_for_meta_in_messages

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2485,5 +2485,7 @@
       properties:
         key:
           type: "string"
+          example: "subject"
         value:
           type: "string"
+          example: "Mail subject"


### PR DESCRIPTION
Example for how to use meta in message, like a key / value "subject" / "mail subject".
