### PR TITLE
Feature bot 903 filter on impacts

### DIFF
--- a/chaos/formats.py
+++ b/chaos/formats.py
@@ -47,6 +47,7 @@ pt_object_type_values = [
     "stop_point"
 ]
 # Here Order of values is strict and is used to create query filters.
+application_status_values = ["past", "ongoing", "coming"]
 publication_status_values = ["past", "ongoing", "coming"]
 time_pattern = '^\d{2}:\d{2}$'
 week_pattern = '^[0-1]{7,7}$'
@@ -408,6 +409,11 @@ disruptions_search_input_format = {
                 },
                 'required': ['id']
             },
+            'uniqueItems': True
+        },
+        'application_status': {
+            'type': 'array',
+            'items': {'enum': application_status_values},
             'uniqueItems': True
         },
         'publication_status': {

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -441,7 +441,7 @@ class Disruption(TimestampMixin, db.Model):
     )
     start_publication_date = db.Column(db.DateTime(), nullable=True)
     end_publication_date = db.Column(db.DateTime(), nullable=True)
-    impacts = db.relationship('Impact', backref='disruption', lazy='joined', cascade='delete', innerjoin=True)
+    impacts = db.relationship('Impact', backref='disruption', lazy='joined', cascade='delete')
     cause_id = db.Column(UUID, db.ForeignKey(Cause.id))
     cause = db.relationship('Cause', backref='disruption', lazy='joined')
     tags = db.relationship("Tag", secondary=associate_disruption_tag, backref="disruptions", lazy='joined')

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -508,7 +508,8 @@ class Disruption(TimestampMixin, db.Model):
             application_status=application_status_values,
             query=None,
             cause_category_id=None,
-            current_time=get_current_time()):
+            current_time=None):
+        if current_time is None: current_time = get_current_time()
         if (query is None):
             query = cls.query
 
@@ -593,7 +594,8 @@ class Disruption(TimestampMixin, db.Model):
             statuses,
             ptObjectFilter,
             cause_category_id,
-            current_time=get_current_time()):
+            current_time=None):
+        if current_time is None: current_time = get_current_time()
         query = cls.query
         object_types = []
         uris = []

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -31,12 +31,13 @@
 
 import uuid
 from chaos import db, utils, exceptions
-from utils import paginate, get_current_time
+from utils import paginate, get_current_time, uri_is_not_in_pt_object_filter
 from sqlalchemy.dialects.postgresql import UUID, BIT
 from datetime import datetime
 from formats import publication_status_values, application_status_values
 from sqlalchemy import or_, and_, between
 from sqlalchemy.orm import aliased
+import logging
 
 #force the server to use UTC time for each connection checkouted from the pool
 import sqlalchemy
@@ -440,7 +441,7 @@ class Disruption(TimestampMixin, db.Model):
     )
     start_publication_date = db.Column(db.DateTime(), nullable=True)
     end_publication_date = db.Column(db.DateTime(), nullable=True)
-    impacts = db.relationship('Impact', backref='disruption', lazy='joined', cascade='delete')
+    impacts = db.relationship('Impact', backref='disruption', lazy='joined', cascade='delete', innerjoin=True)
     cause_id = db.Column(UUID, db.ForeignKey(Cause.id))
     cause = db.relationship('Cause', backref='disruption', lazy='joined')
     tags = db.relationship("Tag", secondary=associate_disruption_tag, backref="disruptions", lazy='joined')
@@ -497,7 +498,6 @@ class Disruption(TimestampMixin, db.Model):
     def get_query_with_args(
             cls,
             contributor_id,
-            application_status,
             publication_status,
             ends_after_date,
             ends_before_date,
@@ -505,8 +505,10 @@ class Disruption(TimestampMixin, db.Model):
             uri,
             line_section,
             statuses,
+            application_status=application_status_values,
             query=None,
-            cause_category_id=None):
+            cause_category_id=None,
+            current_time=get_current_time()):
         if (query is None):
             query = cls.query
 
@@ -542,10 +544,10 @@ class Disruption(TimestampMixin, db.Model):
             query = query.filter(PTobject.uri == uri)
 
         publication_availlable_filters = {
-            'past': and_(cls.end_publication_date != None, cls.end_publication_date < get_current_time()),
-            'ongoing': and_(cls.start_publication_date <= get_current_time(),
-                            or_(cls.end_publication_date == None, cls.end_publication_date >= get_current_time())),
-            'coming': Disruption.start_publication_date > get_current_time()
+            'past': and_(cls.end_publication_date != None, cls.end_publication_date < current_time),
+            'ongoing': and_(cls.start_publication_date <= current_time,
+                            or_(cls.end_publication_date == None, cls.end_publication_date >= current_time)),
+            'coming': Disruption.start_publication_date > current_time
         }
         publication_status = set(publication_status)
         if len(publication_status) == len(publication_status_values):
@@ -565,14 +567,15 @@ class Disruption(TimestampMixin, db.Model):
         application_status = set(application_status)
         if len(application_status) != len(application_status_values):
             query = query.join(cls.impacts)
+            query = query.filter(Impact.status == 'published')
+            query = query.join(Impact.application_periods)
             application_availlable_filters = {
-                'past': ApplicationPeriods.end_date < get_current_time(),
-                'ongoing': and_(ApplicationPeriods.start_date >= get_current_time(), ApplicationPeriods.end_date <= get_current_time()),
-                'coming': ApplicationPeriods.start_date > get_current_time()
+                'past': ApplicationPeriods.end_date < current_time,
+                'ongoing': and_(ApplicationPeriods.start_date <= current_time, ApplicationPeriods.end_date >= current_time),
+                'coming': ApplicationPeriods.start_date > current_time
             }
             filters = [application_availlable_filters[status] for status in application_status]
             query = query.filter(or_(*filters))
-
         return query.order_by(cls.end_publication_date, cls.id)
 
     @classmethod
@@ -589,13 +592,15 @@ class Disruption(TimestampMixin, db.Model):
             line_section,
             statuses,
             ptObjectFilter,
-            cause_category_id):
+            cause_category_id,
+            current_time=get_current_time()):
         query = cls.query
         object_types = []
         uris = []
         line_section_uris = []
-
-        if uri is None and ptObjectFilter is not None:
+        if uri_is_not_in_pt_object_filter(uri=uri, pt_object_filter=ptObjectFilter):
+            return cls.query.filter('1=0')
+        if ptObjectFilter is not None:
             for key, objectIds in ptObjectFilter.iteritems():
                 object_type = key[:-1]
                 object_types.append(object_type)
@@ -619,7 +624,6 @@ class Disruption(TimestampMixin, db.Model):
                 )
             else:
                 query = cls.query.filter(uris_filter)
-
         return cls.get_query_with_args(
             contributor_id=contributor_id,
             application_status=application_status,
@@ -631,7 +635,8 @@ class Disruption(TimestampMixin, db.Model):
             line_section=line_section,
             statuses=statuses,
             query=query,
-            cause_category_id=cause_category_id
+            cause_category_id=cause_category_id,
+            current_time=current_time
         )
 
     @classmethod

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -37,7 +37,7 @@ from fields import *
 from formats import *
 from formats import impact_input_format, channel_input_format, pt_object_type_values,\
     tag_input_format, category_input_format, channel_type_values,\
-    property_input_format, disruptions_search_input_format
+    property_input_format, disruptions_search_input_format, application_status_values
 from chaos import mapper, exceptions
 from chaos import utils, db_helper
 import chaos
@@ -488,6 +488,7 @@ class DisruptionsSearch(flask_restful.Resource):
             page_index=args['start_page'],
             items_per_page=args['items_per_page'],
             contributor_id=contributor.id,
+            application_status=json.get('application_status', application_status_values),
             publication_status=json.get('publication_status', publication_status_values),
             ends_after_date=args['ends_after_date'],
             ends_before_date=args['ends_before_date'],

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -733,7 +733,7 @@ def uri_is_not_in_pt_object_filter(uri=None, pt_object_filter=None):
     return not result
 
 
-def has_impact_deleted_by_application_status(application_status, application_periods, current_time=get_current_time()):
+def has_impact_deleted_by_application_status(application_status, application_periods, current_time=None):
     """
         Return if an impact should be deleted by his application_period.
 
@@ -743,6 +743,7 @@ def has_impact_deleted_by_application_status(application_status, application_per
         :return: True if the impact does not activate in a certain time status ['past', 'ongoing', 'coming']
         :rtype: bool
     """
+    if current_time is None: current_time = get_current_time()
     impact_is_deleted = True
     for application_period in application_periods:
         if 'past' in application_status:
@@ -787,7 +788,7 @@ def filter_disruptions_on_impacts(
     disruptions,
     pt_object_filter=None,
     uri=None,
-    current_time=get_current_time(),
+    current_time=None,
     application_status = ['past', 'ongoing', 'coming']
     ):
     """
@@ -801,6 +802,7 @@ def filter_disruptions_on_impacts(
         :return: Nothing
         :rtype: Void
     """
+    if current_time is None: current_time = get_current_time()
     if len(application_status) != 3:
         for disruption in disruptions[:]:
             deleted_impacts = []

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1275,7 +1275,7 @@
 
     /disruptions/_search:
       post:
-        description: Return filtered disruptions
+        description: Return filtered disruptions and impacts
         parameters:
         - $ref: "#/parameters/header_authorization"
         - $ref: "#/parameters/header_coverage"
@@ -2272,8 +2272,21 @@
           description: Number of items per page
           type: integer
           default: 20
+        application_status:
+          description: Filter by application_status (on impact)
+          default:
+            - past
+            - ongoing
+            - coming
+          type: array
+          items:
+            type: string
+            enum:
+              - past
+              - ongoing
+              - coming
         publication_status:
-          description: Filter by publication_status
+          description: Filter by publication_status (on disruption)
           default:
             - past
             - ongoing

--- a/tests/features/list-disruptions-search-post.feature
+++ b/tests/features/list-disruptions-search-post.feature
@@ -671,3 +671,148 @@ Feature: list disruptions with ptObjects filter
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
+
+    Scenario: Filter on line with application_status
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+            | foo2      | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b7 | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b7 | 7ffab230-3d48-4eea-aa2c-22f8680230b7 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b8 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-04-10 16:52:00                  |2014-04-17 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-04-17 16:52:00                  |2014-04-19 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab232-3d47-4eea-aa2c-22f8680230b8 |2014-04-10 16:52:00                  |2014-04-14 16:52:00 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status": ["ongoing"]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status": ["coming"]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status": ["past"]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status": ["ongoing", "coming"]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        And the field "disruptions.1.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.impacts.impacts" should have a size of 2
+        And the field "disruptions.1.impacts.impacts" should have a size of 1
+@test
+    Scenario: Filter on ptojbect return correct impacts
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b7 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type  | uri           | created_at          | id                                         |
+            | line  | line:JDR:M1   | 2014-04-04T23:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line  | line:JDR:M2   | 2014-04-06T22:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b7       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b7          | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-04-10 16:52:00                  |2014-04-17 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-04-10 16:52:00                  |2014-04-17 16:52:00 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status":["ongoing"], "ptObjectFilter": {"lines": ["line:JDR:M1"]}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status":["ongoing"], "ptObjectFilter": {"lines": ["line:JDR:M2"]}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_status":["ongoing"], "ptObjectFilter": {"lines": ["line:JDR:M2", "line:JDR:M1"]}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 2


### PR DESCRIPTION
# Description

This PR adds ~feature~ documentation filter on impacts

## Issue (optional)

Issue link: BOT-903

## Pull Request type

This is a new feature

## How to test

Here are the following steps to test this pull request:

- from TR, you can see that Dashboard view is filtered by impacts ongoing / coming. Previously it was by Disruptions


:grey_exclamation: waiting for https://github.com/CanalTP/Chaos/pull/326