### PR TITLE
Update doc swagger

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1942,6 +1942,11 @@
           items:
             description: "Id of line object"
             type: "string"
+        routes:
+          type: "array"
+          items:
+            description: "Id of route object"
+            type: "string"
         stop_points:
           type: "array"
           items:


### PR DESCRIPTION
# Description

This PR add `routes` parameters to `pt_object_filter`

http://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/feature-bot-1010-add-routes-filter/documentation/swagger.yml#/Search/post_disruptions__search

## Issue

Issue link: BOT-1010