### PR TITLE
Feature bot 733 add application period filter

### DIFF
--- a/chaos/formats.py
+++ b/chaos/formats.py
@@ -452,6 +452,14 @@ disruptions_search_input_format = {
                     'uniqueItems': True
                 }
             }
+        },
+        'application_period': {
+            'type': 'object',
+            'properties': {
+                'begin': {'type': ['string'], 'pattern': datetime_pattern},
+                'end': {'type': ['string'], 'pattern': datetime_pattern}
+            },
+            'required': ['begin', 'end']
         }
     }
 }

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -594,6 +594,7 @@ class Disruption(TimestampMixin, db.Model):
             statuses,
             ptObjectFilter,
             cause_category_id,
+            application_period,
             current_time=None):
         if current_time is None: current_time = get_current_time()
         query = cls.query
@@ -626,6 +627,24 @@ class Disruption(TimestampMixin, db.Model):
                 )
             else:
                 query = cls.query.filter(uris_filter)
+        if application_period is not None:
+            query = cls.query.filter(
+                cls.impacts.any(Impact.application_periods.any(
+                or_(
+                    and_(
+                        ApplicationPeriods.start_date >= application_period['begin'],
+                        ApplicationPeriods.start_date <= application_period['end']
+                    ),
+                    and_(
+                        ApplicationPeriods.end_date >= application_period['begin'],
+                        ApplicationPeriods.end_date <= application_period['end']
+                    ),
+                    and_(
+                        ApplicationPeriods.start_date <= application_period['begin'],
+                        ApplicationPeriods.end_date >= application_period['end']
+                    )
+                )
+            )))
         return cls.get_query_with_args(
             contributor_id=contributor_id,
             application_status=application_status,

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -487,6 +487,8 @@ class DisruptionsSearch(flask_restful.Resource):
         application_status=json.get('application_status', application_status_values)
         uri=json.get('uri', None)
         ptObjectFilter=json.get('ptObjectFilter', None)
+        application_period = json.get('application_period', None)
+
         result = models.Disruption.all_with_post_filter(
             page_index=args['start_page'],
             items_per_page=args['items_per_page'],
@@ -501,6 +503,7 @@ class DisruptionsSearch(flask_restful.Resource):
             statuses=json.get('status', disruption_status_values),
             ptObjectFilter=ptObjectFilter,
             cause_category_id=json.get('cause_category_id', None),
+            application_period=application_period,
             current_time=current_time
         )
         utils.filter_disruptions_on_impacts(
@@ -508,7 +511,8 @@ class DisruptionsSearch(flask_restful.Resource):
             current_time=current_time,
             uri=uri,
             pt_object_filter=ptObjectFilter,
-            application_status=application_status
+            application_status=application_status,
+            application_period=application_period
         )
         response = {'disruptions': result.items, 'meta': make_pager(result, 'disruption')}
 

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2319,6 +2319,19 @@
           type: string
           pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
           example: "2018-08-03T12:19:13Z"
+        application_period:
+          required: [begin, end]
+          type: object
+          description: Filter on impact application_period
+          properties:
+            begin:
+              type: string
+              pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+              example: "2018-08-03T12:19:13Z"
+            end:
+              type: string
+              pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+              example: "2018-08-03T12:19:13Z"
         current_time:
           description: Parameter for settings the current time, mostly for debugging purpose
           default: now

--- a/tests/features/list-disruptions-search-post.feature
+++ b/tests/features/list-disruptions-search-post.feature
@@ -749,7 +749,7 @@ Feature: list disruptions with ptObjects filter
         And the field "disruptions" should have a size of 2
         And the field "disruptions.0.impacts.impacts" should have a size of 2
         And the field "disruptions.1.impacts.impacts" should have a size of 1
-@test
+
     Scenario: Filter on ptojbect return correct impacts
 
         Given I have the following clients in my database:
@@ -816,3 +816,68 @@ Feature: list disruptions with ptObjects filter
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
         And the field "disruptions.0.impacts.impacts" should have a size of 2
+
+    Scenario: Filter on application_period return correct impacts
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
+            | foo       | hello | 2014-04-01T00:00:00 | 2014-04-01T00:00:00 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-01T00:00:00    | 2014-04-20T23:42:00  |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type  | uri           | created_at          | id                                         |
+            | line  | line:JDR:M1   | 2014-04-04T23:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b1       |
+            | line  | line:JDR:M2   | 2014-04-06T22:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b2       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b1          | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b2          | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b1 |2014-04-04 16:52:00                  |2014-04-05 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b2 |2014-04-03 16:52:00                  |2014-04-06 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b3 | 7ffab232-3d47-4eea-aa2c-22f8680230b3 |2014-04-02 16:52:00                  |2014-04-07 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b4 | 7ffab232-3d47-4eea-aa2c-22f8680230b4 |2014-04-01 16:52:00                  |2014-04-04 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab232-3d47-4eea-aa2c-22f8680230b5 |2014-04-06 16:52:00                  |2014-04-07 16:52:00 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_period":{"begin": "2014-04-03T00:00:00Z", "end": "2014-04-06T23:59:00Z"}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 5
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "depth":2, "application_period":{"begin": "2014-04-03T00:00:00Z", "end": "2014-04-05T23:59:00Z"}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 4


### PR DESCRIPTION
# Description

This PR adds a feature to search impacts precisely by application_period

## Issue

Issue link: BOT-733

## How to test

Here are the following steps to test this pull request:
- read official doc
- call /disruptions/_search withi body like i.e
`{
    "tag": [],
    "start_page": "1",
    "items_per_page": 25,
    "depth": 2,
    "publication_status": [
        "past",
        "ongoing",
        "coming"
    ],
    "line_section": "true",
    "application_period": {
        "begin": "2018-10-06T00:00:00Z",
        "end": "2018-10-06T23:59:59Z"
    }
}`