### PR TITLE
Using IN condition instead of regexp for line section

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -38,7 +38,6 @@ from formats import publication_status_values, application_status_values
 from sqlalchemy import or_, and_, between, bindparam
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import text
-import logging
 
 #force the server to use UTC time for each connection checkouted from the pool
 import sqlalchemy
@@ -734,7 +733,7 @@ class Disruption(TimestampMixin, db.Model):
             uriFilter = []
             uriFilter.append('po.uri IN :pt_objects_uris')
             if line_section and 'lines' in ptObjectFilter:
-                uriFilter.append('(po.type = :po_type_line_section AND po.uri LIKE ANY (array[:po_line_section_lines]))')
+                uriFilter.append('(po.type = :po_type_line_section AND po_line.uri IN :po_line_section_lines)')
             andwheres.append('('+' OR '.join(uriFilter)+')')
 
         if isinstance(cause_category_id, basestring) and cause_category_id:
@@ -864,8 +863,7 @@ class Disruption(TimestampMixin, db.Model):
                 stmt = stmt.bindparams(bindparam('po_type_line_section', type_=db.String))
                 stmt = stmt.bindparams(bindparam('po_line_section_lines', type_=db.String))
                 vars['po_type_line_section'] = 'line_section'
-                po_line_section_lines = ','.join([id + ':%' for id in ptObjectFilter['lines']])
-                vars['po_line_section_lines'] = po_line_section_lines
+                vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
 
         if isinstance(cause_category_id, basestring) and cause_category_id:
             stmt = stmt.bindparams(bindparam('cause_category_id', type_=db.String))
@@ -974,9 +972,9 @@ class Disruption(TimestampMixin, db.Model):
             vars['pt_objects_uris'] = tuple([id for ids in ptObjectFilter.itervalues() for id in ids])
             if line_section and 'lines' in ptObjectFilter:
                 stmt = stmt.bindparams(bindparam('po_type_line_section', type_=db.String))
-                stmt = stmt.bindparams(bindparam('po_line_section_lines', type_=db.String))
                 vars['po_type_line_section'] = 'line_section'
-                vars['po_line_section_lines'] = ','.join([id + ':%' for id in ptObjectFilter['lines']])
+                stmt = stmt.bindparams(bindparam('po_line_section_lines', type_=db.String))
+                vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
 
         if isinstance(cause_category_id, basestring) and cause_category_id:
             stmt = stmt.bindparams(bindparam('cause_category_id', type_=db.String))
@@ -1140,9 +1138,9 @@ class Disruption(TimestampMixin, db.Model):
             vars['pt_objects_uris'] = tuple([id for ids in ptObjectFilter.itervalues() for id in ids])
             if line_section and 'lines' in ptObjectFilter:
                 stmt = stmt.bindparams(bindparam('po_type_line_section', type_=db.String))
-                stmt = stmt.bindparams(bindparam('po_line_section_lines', type_=db.String))
                 vars['po_type_line_section'] = 'line_section'
-                vars['po_line_section_lines'] = ','.join([id + ':%' for id in ptObjectFilter['lines']])
+                stmt = stmt.bindparams(bindparam('po_line_section_lines', type_=db.String))
+                vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
 
         if ends_after_date:
             stmt = stmt.bindparams(bindparam('ends_after_date', type_=db.Date))


### PR DESCRIPTION
# Description

This PR fixes filter applying when line section parameter is set to true on disruption search API

## Pull Request type

This is a bug fix

## How to test

- request disruptions/_search API using "line_section":"true" in request body
- the results should be filtered by lines used in request body under section "pt_object"

## Team reviewers (optional)
@pthegner 
@kun2985 
