### PR TITLE
Fix uri_like bindparams

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -701,14 +701,13 @@ class Disruption(TimestampMixin, db.Model):
             uri_filters = []
             uri_filters.append('po.uri = :uri')
             bindparams['uri'] = db.String
-            bindparams['uri_like'] = db.String
             vars['uri'] = uri
-            vars['uri_like'] = uri + ':%'
-
             if line_section:
                 uri_filters.append('po.type = :po_type_line_section AND po.uri LIKE :uri_like')
                 bindparams['po_type_line_section'] = db.String
+                bindparams['uri_like'] = db.String
                 vars['po_type_line_section'] = 'line_section'
+                vars['uri_like'] = uri + ':%'
             andwheres.append('(' + ' OR '.join(uri_filters) + ')')
         elif ptObjectFilter is not None:
             uri_filters = []


### PR DESCRIPTION
# Description

Fix bindparams


`Jan 30 15:27:47 chaos-prd-ws2 chaosws-ws.ctp.prod.canaltp.fr: [Wed Jan 30 15:27:47 2019] [error] [client 10.93.4.1] "bound parameter named %r" % bind.key) Jan 30 15:27:47 chaos-prd-ws2 chaosws-ws.ctp.prod.canaltp.fr: [Wed Jan 30 15:27:47 2019] [error] [client 10.93.4.1] ArgumentError: This text() construct doesn't define a bound parameter named 'uri_like'`