### PR TITLE
Fix pager wording

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2683,7 +2683,7 @@
           type: "integer"
         items_per_page:
           type: "integer"
-        total_results:
+        total_result:
           type: "integer"
         prev:
           $ref: "#/definitions/href"


### PR DESCRIPTION
# Description

This PR fix the `s` on the `total_result` entry