### PR TITLE
Default send_notifications to False

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -1131,7 +1131,7 @@ class Impact(TimestampMixin, db.Model):
     objects = db.relationship("PTobject", secondary=associate_impact_pt_object,
                               lazy='joined', order_by="PTobject.type, PTobject.uri")
     patterns = db.relationship('Pattern', backref='impact', lazy='joined', cascade='delete')
-    send_notifications = db.Column(db.Boolean, unique=False, nullable=False, default=True)
+    send_notifications = db.Column(db.Boolean, unique=False, nullable=False, default=False)
     version = db.Column(db.Integer, nullable=False, default=1)
     notification_date = db.Column(db.DateTime(), default=None, nullable=True)
 

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -362,6 +362,7 @@ class Disruptions(flask_restful.Resource):
     @manage_navitia_error()
     @validate_id(True)
     @validate_client_token()
+    @validate_send_notifications_and_notification_date()
     def put(self, client, contributor, navitia, id):
         self.navitia = navitia
         disruption = models.Disruption.get(id, contributor.id)
@@ -1497,6 +1498,7 @@ class Impacts(flask_restful.Resource):
     @validate_contributor()
     @validate_navitia()
     @manage_navitia_error()
+    @validate_send_notifications_and_notification_date()
     def post(self, client, contributor, navitia, disruption_id):
         self.navitia = navitia
         if not id_format.match(disruption_id):
@@ -1547,6 +1549,7 @@ class Impacts(flask_restful.Resource):
     @validate_navitia()
     @manage_navitia_error()
     @validate_id(True)
+    @validate_send_notifications_and_notification_date()
     def put(self, client, contributor, navitia, disruption_id, id):
         self.navitia = navitia
         json = request.get_json(silent=True)

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -49,7 +49,7 @@ from sqlalchemy.exc import IntegrityError
 import logging
 from utils import make_pager, option_value, get_current_time
 from chaos.validate_params import validate_client, validate_contributor, validate_navitia, \
-    manage_navitia_error, validate_id, validate_client_token
+    manage_navitia_error, validate_id, validate_client_token, validate_send_notifications_and_notification_date
 from collections import OrderedDict
 
 __all__ = ['Disruptions', 'Index', 'Severity', 'Cause']
@@ -288,6 +288,7 @@ class Disruptions(flask_restful.Resource):
     @validate_client(True)
     @manage_navitia_error()
     @validate_client_token()
+    @validate_send_notifications_and_notification_date()
     def post(self, client, navitia):
         self.navitia = navitia
         json = request.get_json(silent=True)

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -172,7 +172,7 @@ class validate_send_notifications_and_notification_date(object):
             json = request.get_json(silent=True)
             impacts = json['impacts']
             for impact in impacts:
-                if impact['send_notifications'] and ('notification_date' not in impact):
+                if ('send_notifications' in impact) and impact['send_notifications'] and ('notification_date' not in impact):
                     return resp
             return func(*args, **kwargs)
         return wrapper

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -172,7 +172,7 @@ class validate_send_notifications_and_notification_date(object):
                 if ('send_notifications' in impact) and impact['send_notifications'] and \
                     ('notification_date' not in impact or impact['notification_date'] is None):
                     return marshal(
-                        {'error': {'message': "notification_date should not be null when send_notifications is true"}},
+                        {'error': {'message': "notification_date is mandatory if send_notifications is true"}},
                         fields.error_fields
                     ), 400
             return func(*args, **kwargs)

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -170,9 +170,10 @@ class validate_send_notifications_and_notification_date(object):
                 fields.error_fields
             ), 400
             json = request.get_json(silent=True)
-            impacts = json['impacts']
-            for impact in impacts:
-                if ('send_notifications' in impact) and impact['send_notifications'] and ('notification_date' not in impact):
-                    return resp
+            if json and 'impacts' in json:
+                impacts = json['impacts']
+                for impact in impacts:
+                    if ('send_notifications' in impact) and impact['send_notifications'] and ('notification_date' not in impact):
+                        return resp
             return func(*args, **kwargs)
         return wrapper

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -157,3 +157,22 @@ class validate_client_token(object):
                 ), 401
             return func(*args, **kwargs)
         return wrapper
+
+class validate_send_notifications_and_notification_date(object):
+    def __init__(self, required=False):
+        self.required = required
+
+    def __call__(self, func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            resp = marshal(
+                {'error': {'message': "notification_date should not be null when send_notifications is true"}},
+                fields.error_fields
+            ), 400
+            json = request.get_json(silent=True)
+            impacts = json['impacts']
+            for impact in impacts:
+                if impact['send_notifications'] and ('notification_date' not in impact):
+                    return resp
+            return func(*args, **kwargs)
+        return wrapper

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2244,6 +2244,7 @@
             $ref: "#/definitions/period_create"
         send_notifications:
           type: boolean
+          default: false
           description: If notification sms, mail, push on impact should be send
         notification_date:
           description: Date of notification
@@ -2510,6 +2511,7 @@
         send_notifications:
           description: "If notification should be send or not"
           type: "boolean"
+          default: false
         severity:
           description: "Related severity"
           $ref: "#/definitions/severity"
@@ -2602,6 +2604,7 @@
         send_notifications:
           description: "If notification should be send or not"
           type: "boolean"
+          default: false
         notification_date:
           description: "Date of notification"
           type: "string"
@@ -2644,11 +2647,6 @@
           type: "array"
           items:
             $ref: "#/definitions/impact_message"
-        notification_date:
-          description: "Date of notification"
-          type: "string"
-          pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
-          example: "2018-08-03T12:19:13Z"
         objects:
           type: "array"
           description: "List with impacted PT objects"
@@ -2669,6 +2667,12 @@
         send_notifications:
           description: "If notification should be send or not"
           type: "boolean"
+          default: false
+        notification_date:
+          description: "Date of notification"
+          type: "string"
+          pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+          example: "2018-08-03T12:19:13Z"
         severity:
           description: "Related severity"
           $ref: "#/definitions/severity"

--- a/tests/features/create-disruption-with-impacts.feature
+++ b/tests/features/create-disruption-with-impacts.feature
@@ -203,4 +203,4 @@ Feature: Create Disruption and impacts
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "notification_date should not be null when send_notifications is true"
+        And the field "error.message" should be "notification_date is mandatory if send_notifications is true"

--- a/tests/features/create-disruption-with-impacts.feature
+++ b/tests/features/create-disruption-with-impacts.feature
@@ -149,3 +149,63 @@ Feature: Create Disruption and impacts
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "'value' is a required property"
+
+    Scenario: creation of disruption with one impact and send_notifications not exist
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        Given I post to "/disruptions" with:
+        """
+        {"reference": "foo","contributor": "contrib1","note": "hello","cause": {"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions.0.impacts.0.send_notifications" should be "False"
+
+    Scenario: creation of disruption with one impact and notification_date not exist when send_notifications is true
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        Given I post to "/disruptions" with:
+        """
+        {"reference": "foo","contributor": "contrib1","note": "hello","cause": {"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"send_notifications":true,"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I get "/disruptions"
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "notification_date should not be null when send_notifications is true"

--- a/tests/features/create-disruption-with-impacts.feature
+++ b/tests/features/create-disruption-with-impacts.feature
@@ -197,15 +197,10 @@ Feature: Create Disruption and impacts
         I fill in header "X-Customer-Id" with "5"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        Given I post to "/disruptions" with:
+        When I post to "/disruptions" with:
         """
         {"reference": "foo","contributor": "contrib1","note": "hello","cause": {"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"send_notifications":true,"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
         """
-        I fill in header "X-Customer-Id" with "5"
-        I fill in header "X-Coverage" with "jdr"
-        I fill in header "X-Contributors" with "contrib1"
-        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I get "/disruptions"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "notification_date should not be null when send_notifications is true"

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -587,7 +587,7 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.severity.wording" should be "good news"
         And the field "impact.disruption.href" should exist
         And the field "impact.self.href" should exist
-        And the field "impact.send_notifications" should be "True"
+        And the field "impact.send_notifications" should be "False"
 
     Scenario: Add an impact in a disruption with notification_date
 
@@ -629,7 +629,7 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.severity.wording" should be "good news"
         And the field "impact.disruption.href" should exist
         And the field "impact.self.href" should exist
-        And the field "impact.send_notifications" should be "True"
+        And the field "impact.send_notifications" should be "False"
         And the field "impact.notification_date" should be "2014-06-24T10:35:00Z"
 
 
@@ -674,7 +674,7 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.severity.wording" should be "good news"
         And the field "impact.disruption.href" should exist
         And the field "impact.self.href" should exist
-        And the field "impact.send_notifications" should be "True"
+        And the field "impact.send_notifications" should be "False"
         And the field "impact.notification_date" should be null
 
 

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -492,7 +492,7 @@ Feature: Manipulate impacts in a Disruption
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
         """
-        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "send_notifications": true}
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "send_notifications": true, "notification_date": "2014-04-06T22:52:12Z"}
         """
         Then the status code should be "201"
         And the header "Content-Type" should be "application/json"
@@ -712,4 +712,3 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "u'' does not match '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$'"
-

--- a/tests/features/steps.py
+++ b/tests/features/steps.py
@@ -238,7 +238,11 @@ def and_the_field_group1_is_valid_impact(step, group1):
     assert(date_is_valid(impact.get('created_at')))
     assert(impact.get('severity'))
     assert(impact.get('disruption'))
-    assert(False == impact.get('send_notifications'))
+    if 'send_notifications' in impact:
+        assert(isinstance(impact.get('send_notifications'), bool))
+        if impact.get('send_notifications'):
+            assert(impact.get('notification_date'))
+            assert(date_is_valid(impact.get('notification_date')))
     if impact.get('updated_at'):
         assert(date_is_valid(impact.get('updated_at')))
 

--- a/tests/features/steps.py
+++ b/tests/features/steps.py
@@ -238,7 +238,7 @@ def and_the_field_group1_is_valid_impact(step, group1):
     assert(date_is_valid(impact.get('created_at')))
     assert(impact.get('severity'))
     assert(impact.get('disruption'))
-    assert(impact.get('send_notifications'))
+    assert(False == impact.get('send_notifications'))
     if impact.get('updated_at'):
         assert(date_is_valid(impact.get('updated_at')))
 


### PR DESCRIPTION
# Description

This PR fix the logic behind the send_notifications behavior

Doc : http://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/feature-bot-1156-send-notifications-default-false/documentation/swagger.yml

## Issue

Issue link: BOT-1156

## How to test

Here are the following steps to test this pull request:

- create a disruption with an impact and test the parameters `send_notifications` and `notification_date`