### PR TITLE
add a migration file in order to fix send_notifications values in database

### DIFF
--- a/migrations/versions/463b471b2a9a_update_impact_send_notifications_values.py
+++ b/migrations/versions/463b471b2a9a_update_impact_send_notifications_values.py
@@ -1,0 +1,21 @@
+"""update impact send_notifications values
+
+Revision ID: 463b471b2a9a
+Revises: dfe97c5974e3
+Create Date: 2019-03-22 12:19:48.562886
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '463b471b2a9a'
+down_revision = 'dfe97c5974e3'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute('update impact set send_notifications = false where notification_date is null')
+
+def downgrade():
+    # doing send_notifications = true isn't what we want so downgrade is empty
+    pass


### PR DESCRIPTION
# Description

This PR fixes a problem with a new checker which verify that impacts with send_notifications field set to true have also a notification_date.
Before this commit https://github.com/CanalTP/Chaos/commit/d3d9fcaef5b6d31be9b2962f8d7e40c67d028ea5, all impacts pushed to chaos without send_notifications field are saved in database with the column send_notifications = TRUE and notification_date = NULL.
So I add a migration file in order to clean the database where "send_notifications" column = true and "notification_date" column is empty.
