### PR TITLE
[notification_date] Migration to get a value for old impacts

### DIFF
--- a/migrations/versions/463b471b2a9a_update_impact_send_notifications_values.py
+++ b/migrations/versions/463b471b2a9a_update_impact_send_notifications_values.py
@@ -14,8 +14,7 @@ from alembic import op
 
 
 def upgrade():
-    op.execute('update impact set send_notifications = false where notification_date is null')
+    op.execute('UPDATE impact SET notification_date = COALESCE(updated_at, created_at) WHERE send_notifications = true AND notification_date IS null')
 
 def downgrade():
-    # doing send_notifications = true isn't what we want so downgrade is empty
     pass


### PR DESCRIPTION
# Description

This PR fix the migration in order to have a correct history (when send_notifications = true -> manage like a notification even if notification_date is null)

@vpassama , after some brainstorming about your old PR, we have another solution to this problem of notification_date null when send_notifications = true. Could you check it if it's ok with you.
