### PR TITLE
Update requirements.txt for MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ jsonschema==2.3.0
 kombu==3.0.37
 lettuce==0.2.19
 Mako==0.9.1
-MarkupSafe==0.18
+MarkupSafe==0.23
 mock==1.0.1
 nose==1.3.3
 protobuf==2.6.0


### PR DESCRIPTION
# Description
jinja2 2.10.1 has requirement MarkupSafe>=0.23, but you'll have markupsafe 0.18 which is incompatible.
