### PR TITLE
History disruption step 1

### DIFF
--- a/chaos/api.py
+++ b/chaos/api.py
@@ -50,6 +50,10 @@ api.add_resource(resources.ImpactsSearch,
                  '/impacts/_search',
                  endpoint='impacts_search')
 
+api.add_resource(resources.DisruptionsHistory,
+                 '/disruptions/<string:disruption_id>/history',
+                 endpoint='disruption_history')
+
 api.add_resource(resources.Disruptions,
                  '/disruptions',
                  '/disruptions/<string:id>',

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -1063,7 +1063,7 @@ class Disruption(TimestampMixin, db.Model):
 
     @classmethod
     def get_history_by_id(cls, disruption_id):
-        query_parts = []
+        query_parts = {}
         query_parts['select_columns'] = [
             'd.id', 'd.reference', 'd.note', 'd.status', 'd.version', 'd.created_at', 'd.updated_at',
             'd.start_publication_date', 'd.end_publication_date',
@@ -1107,8 +1107,8 @@ class Disruption(TimestampMixin, db.Model):
         ]
         join_tables = []
         join_tables.append('(SELECT * FROM (' \
-                           ' SELECT created_at, updated_at,id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status::text from public.disruption where public.disruption.id = \':disruption_id\' UNION' \
-                           ' SELECT created_at, updated_at,disruption_id as id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status from history.disruption where history.disruption.disruption_id = \':disruption_id\') as disruption_union' \
+                           ' SELECT created_at, updated_at,id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status::text from public.disruption where public.disruption.id = :disruption_id UNION' \
+                           ' SELECT created_at, updated_at,disruption_id as id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status from history.disruption where history.disruption.disruption_id = :disruption_id) as disruption_union' \
                            ' ORDER BY version, updated_at) AS d')
         join_tables.append('LEFT JOIN impact i ON (i.disruption_id = d.id)')
         join_tables.append('LEFT JOIN cause c ON (d.cause_id = c.id)')

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -1061,6 +1061,103 @@ class Disruption(TimestampMixin, db.Model):
 
         return db.engine.execute(stmt, vars).fetchall()
 
+    @classmethod
+    def get_history_by_id(cls, disruption_id):
+        query_parts = []
+        query_parts['select_columns'] = [
+            'd.id', 'd.reference', 'd.note', 'd.status', 'd.version', 'd.created_at', 'd.updated_at',
+            'd.start_publication_date', 'd.end_publication_date',
+            'i.id AS impact_id', 'i.created_at AS impact_created_at', 'i.updated_at AS impact_updated_at',
+            'i.send_notifications AS impact_send_notifications', 'i.notification_date AS impact_notification_date',
+            'c.id AS cause_id', 'c.created_at AS cause_created_at', 'c.updated_at AS cause_updated_at',
+            'ctg.id AS cause_category_id', 'ctg.name AS cause_category_name',
+            'ctg.created_at AS cause_category_created_at',
+            'ctg.updated_at AS cause_category_updated_at', 'cw.id AS cause_wording_id', 'cw.key AS cause_wording_key',
+            'cw.value AS cause_wording_value', 's.created_at AS severity_created_at',
+            's.updated_at AS severity_updated_at',
+            's.id AS severity_id', 's.wording AS severity_wording', 's.color AS severity_color',
+            's.is_visible AS severity_is_visible',
+            's.priority AS severity_priority', 's.effect AS severity_effect', 's.client_id AS severity_client_id',
+            'sw.id AS severity_wording_id', 'sw.key AS severity_wording_key', 'sw.value AS severity_wording_value',
+            'contrib.contributor_code AS contributor_code', 't.id AS tag_id', 't.name AS tag_name',
+            't.created_at AS tag_created_at',
+            't.updated_at AS tag_updated_at', 'p.id AS property_id', 'p.key AS property_key', 'p.type AS property_type',
+            'adp.value AS property_value', 'p.created_at AS property_created_at', 'p.updated_at AS property_updated_at',
+            'localization.uri AS localization_uri', 'localization.type AS localization_type',
+            'localization.id AS localization_id',
+            'po.id AS pt_object_id', 'po.type AS pt_object_type', 'po.uri AS pt_object_uri',
+            'ap.id AS application_period_id',
+            'ap.start_date AS application_period_start_date', 'ap.end_date AS application_period_end_date',
+            'm.id AS message_id', 'm.created_at AS message_created_at', 'm.updated_at AS message_updated_at',
+            'm.text AS message_text', 'ch.id AS channel_id', 'ch.content_type AS channel_content_type',
+            'ch.created_at AS channel_created_at', 'ch.updated_at AS channel_updated_at',
+            'ch.max_size AS channel_max_size',
+            'ch.name AS channel_name', 'ch.required AS channel_required', 'cht.id AS channel_type_id',
+            'cht.name AS channel_type_name',
+            'me.id AS meta_id', 'me.key AS meta_key', 'me.value AS meta_value',
+            'pa.id AS pattern_id, pa.start_date AS pattern_start_date, pa.end_date AS pattern_end_date, pa.weekly_pattern AS pattern_weekly_pattern',
+            'ts.id AS time_slot_id, ts.begin AS time_slot_begin, ts.end AS time_slot_end',
+            'ls.id AS line_section_id, ls.sens AS line_section_sens',
+            'po_line.uri AS line_section_line_uri, po_line.type AS line_section_line_type',
+            'po_start.uri AS line_section_start_uri, po_start.type AS line_section_start_type',
+            'po_end.uri AS line_section_end_uri, po_end.type AS line_section_end_type',
+            'po_route.id AS po_route_id, po_route.uri AS po_route_uri, po_route.type AS po_route_type',
+            'awlsw.id AS awlsw_id, awlsw.key AS awlsw_key, awlsw.value AS awlsw_value',
+            'po_via.id AS po_via_id, po_via.uri AS po_via_uri, po_via.type AS po_via_type'
+        ]
+        join_tables = []
+        join_tables.append('(SELECT * FROM (' \
+                           ' SELECT created_at, updated_at,id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status::text from public.disruption where public.disruption.id = \':disruption_id\' UNION' \
+                           ' SELECT created_at, updated_at,disruption_id as id,reference,note,start_publication_date,end_publication_date,version,client_id , contributor_id,cause_id,status from history.disruption where history.disruption.disruption_id = \':disruption_id\') as disruption_union' \
+                           ' ORDER BY version, updated_at) AS d')
+        join_tables.append('LEFT JOIN impact i ON (i.disruption_id = d.id)')
+        join_tables.append('LEFT JOIN cause c ON (d.cause_id = c.id)')
+        join_tables.append('LEFT JOIN category ctg ON (c.category_id = ctg.id)')
+        join_tables.append('LEFT JOIN associate_wording_cause awc ON (c.id = awc.cause_id)')
+        join_tables.append('LEFT JOIN severity AS s ON (s.id = i.severity_id)')
+        join_tables.append('LEFT JOIN wording AS cw ON (awc.wording_id = cw.id)')
+        join_tables.append('LEFT JOIN associate_wording_severity aws ON (s.id = aws.severity_id)')
+        join_tables.append('LEFT JOIN wording AS sw ON (aws.wording_id = sw.id)')
+        join_tables.append('LEFT JOIN contributor AS contrib ON (contrib.id = d.contributor_id)')
+        join_tables.append('LEFT JOIN associate_disruption_tag adt ON (d.id = adt.disruption_id)')
+        join_tables.append('LEFT JOIN tag t ON (t.id = adt.tag_id)')
+        join_tables.append('LEFT JOIN associate_disruption_property AS adp ON (d.id = adp.disruption_id)')
+        join_tables.append('LEFT JOIN property AS p ON (p.id = adp.property_id)')
+        join_tables.append('LEFT JOIN associate_disruption_pt_object AS adpo ON (adpo.disruption_id = d.id)')
+        join_tables.append('LEFT JOIN pt_object AS localization ON (localization.id = adpo.pt_object_id)')
+        join_tables.append('LEFT JOIN associate_impact_pt_object AS aipto ON (aipto.impact_id = i.id)')
+        join_tables.append('LEFT JOIN pt_object AS po ON (po.id = aipto.pt_object_id)')
+        join_tables.append('LEFT JOIN application_periods AS ap ON (ap.impact_id = i.id)')
+        join_tables.append('LEFT JOIN message AS m ON (m.impact_id = i.id)')
+        join_tables.append('LEFT JOIN channel AS ch ON (m.channel_id = ch.id)')
+        join_tables.append('LEFT JOIN channel_type AS cht ON (cht.channel_id = ch.id)')
+        join_tables.append('LEFT JOIN associate_message_meta AS amm ON (amm.message_id = m.id)')
+        join_tables.append('LEFT JOIN meta AS me ON (amm.meta_id = me.id)')
+        join_tables.append('LEFT JOIN pattern AS pa ON (pa.impact_id = i.id)')
+        join_tables.append('LEFT JOIN time_slot AS ts ON (ts.pattern_id = pa.id)')
+        join_tables.append('LEFT JOIN line_section AS ls ON (po.id = ls.object_id)')
+        join_tables.append('LEFT JOIN pt_object AS po_line ON (po_line.id = ls.line_object_id)')
+        join_tables.append('LEFT JOIN pt_object AS po_start ON (po_start.id = ls.start_object_id)')
+        join_tables.append('LEFT JOIN pt_object AS po_end ON (po_end.id = ls.end_object_id)')
+        join_tables.append('LEFT JOIN associate_line_section_route_object AS alsro ON (alsro.line_section_id = ls.id)')
+        join_tables.append('LEFT JOIN pt_object AS po_route ON (alsro.route_object_id = po_route.id)')
+        join_tables.append('LEFT JOIN associate_line_section_via_object AS alsvo ON (alsvo.line_section_id = ls.id)')
+        join_tables.append('LEFT JOIN pt_object AS po_via ON (alsvo.stop_area_object_id = po_via.id)')
+        join_tables.append('LEFT JOIN associate_wording_line_section AS awls ON (awls.line_section_id = ls.id)')
+        join_tables.append('LEFT JOIN wording AS awlsw ON (awls.wording_id = awlsw.id)')
+
+        columns = ','.join(query_parts['select_columns'])
+        tables = ' '.join(join_tables)
+
+        query = 'SELECT %s FROM %s' % (columns, tables)
+
+        stmt = text(query)
+        stmt = stmt.bindparams(bindparam('disruption_id', type_=db.String))
+        vars = {}
+        vars['disruption_id'] = disruption_id
+
+        return db.engine.execute(stmt, vars)
+
 
     @classmethod
     @paginate()

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -2332,7 +2332,10 @@ class DisruptionsHistory(flask_restful.Resource):
                         pt_object['line_section']['routes'] = line_section_routes[impact_pt_object_id].values()
                     if impact_pt_object_id in line_section_metas[disruptionVersion]:
                         pt_object['line_section']['wordings'] = line_section_metas[impact_pt_object_id].values()
-
+        if len(disruptions) == 0:
+            return marshal({
+                'error': {'message': 'Disruption {} not found'.format(disruption_id)}
+            }, error_fields), 404
         rawData = {'disruptions': disruptions.values()}
         result = marshal(rawData, disruptions_fields)
         return result

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -63,7 +63,7 @@
     - name: Traffic Reports
     - name: Search
     - name: Export
-    - name: WIP
+    - name: WIP (Work In Progress)
 
 
   ################################################################################

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1262,17 +1262,6 @@
         - $ref: "#/parameters/header_coverage"
         - $ref: "#/parameters/header_customer_id"
         - $ref: "#/parameters/header_contributors"
-        - $ref: "#/parameters/start_page"
-        - $ref: "#/parameters/items_per_page"
-        - $ref: "#/parameters/publication_status"
-        - $ref: "#/parameters/ends_after_date"
-        - $ref: "#/parameters/ends_before_date"
-        - $ref: "#/parameters/current_time"
-        - $ref: "#/parameters/tag"
-        - $ref: "#/parameters/uri"
-        - $ref: "#/parameters/line_section"
-        - $ref: "#/parameters/status"
-        - $ref: "#/parameters/depth"
         - name: id
           in: path
           required: true

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -63,7 +63,7 @@
     - name: Traffic Reports
     - name: Search
     - name: Export
-    - name: WIP (Work In Progress)
+    - name: History (Work In Progress)
 
 
   ################################################################################
@@ -1256,7 +1256,7 @@
 
     /disruptions/{id}/history:
       get:
-        description: Return all histories of one disruption
+        description: Get a list of historical states of a disruption
         parameters:
         - $ref: "#/parameters/header_authorization"
         - $ref: "#/parameters/header_coverage"
@@ -1268,7 +1268,7 @@
           type: string
           description: Entity identifier
         tags:
-          - WIP (Work In Progress)
+          - History (Work In Progress)
         responses:
           200:
             description: List of disruption histories

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -63,6 +63,7 @@
     - name: Traffic Reports
     - name: Search
     - name: Export
+    - name: WIP
 
 
   ################################################################################
@@ -1252,6 +1253,57 @@
             description: Service unavailable
             schema:
               $ref: "#/definitions/error_occured"
+
+    /disruptions/{id}/history:
+      get:
+        description: Return all histories of one disruption
+        parameters:
+        - $ref: "#/parameters/header_authorization"
+        - $ref: "#/parameters/header_coverage"
+        - $ref: "#/parameters/header_customer_id"
+        - $ref: "#/parameters/header_contributors"
+        - $ref: "#/parameters/start_page"
+        - $ref: "#/parameters/items_per_page"
+        - $ref: "#/parameters/publication_status"
+        - $ref: "#/parameters/ends_after_date"
+        - $ref: "#/parameters/ends_before_date"
+        - $ref: "#/parameters/current_time"
+        - $ref: "#/parameters/tag"
+        - $ref: "#/parameters/uri"
+        - $ref: "#/parameters/line_section"
+        - $ref: "#/parameters/status"
+        - $ref: "#/parameters/depth"
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: Entity identifier
+        tags:
+          - WIP
+        responses:
+          200:
+            description: List of disruption histories
+            schema:
+              type: object
+              properties:
+                disruptions:
+                  type: array
+                  items:
+                    $ref: "#/definitions/disruption"
+                meta:
+                  type: object
+                  properties:
+                    pagination:
+                      $ref: "#/definitions/pagination"
+          400:
+            description: Disruption bad id
+            schema:
+              $ref: "#/definitions/error_occured"
+          404:
+            description: Not found
+            schema:
+              $ref: "#/definitions/error_occured"
+
     /disruptions/{id}/impacts:
       get:
         description: Return all impacts of a disruption
@@ -2299,7 +2351,7 @@
             properties:
               id:
                 type: string
-                format: uuid
+                format: string
                 description: Stop area ID
               type:
                 type: string
@@ -2405,7 +2457,7 @@
             properties:
               id:
                 type: string
-                format: uuid
+                format: string
                 description: Stop area ID
               type:
                 type: string

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1268,7 +1268,7 @@
           type: string
           description: Entity identifier
         tags:
-          - WIP
+          - WIP (Work In Progress)
         responses:
           200:
             description: List of disruption histories
@@ -2340,7 +2340,6 @@
             properties:
               id:
                 type: string
-                format: string
                 description: Stop area ID
               type:
                 type: string
@@ -2446,7 +2445,6 @@
             properties:
               id:
                 type: string
-                format: string
                 description: Stop area ID
               type:
                 type: string

--- a/migrations/versions/cf4581a9123_init_history_schema.py
+++ b/migrations/versions/cf4581a9123_init_history_schema.py
@@ -53,10 +53,11 @@ def upgrade():
                     schema='history'
                     )
     op.create_table('associate_disruption_property',
+                    sa.Column('value', sa.Text(), nullable=False),
                     sa.Column('disruption_id', postgresql.UUID(), nullable=False),
                     sa.Column('property_id', postgresql.UUID(), nullable=False),
                     sa.Column('version', sa.Integer(), nullable=False),
-                    sa.PrimaryKeyConstraint('disruption_id', 'property_id', 'version'),
+                    sa.PrimaryKeyConstraint('disruption_id', 'property_id', 'value', 'version'),
                     schema='history'
                     )
     op.execute('CREATE OR REPLACE FUNCTION log_disruption_update() \
@@ -73,8 +74,8 @@ def upgrade():
                  SELECT tag_id,disruption_id,OLD.version FROM public.associate_disruption_tag WHERE disruption_id = OLD.id; \
                  INSERT INTO history.associate_disruption_pt_object(disruption_id,pt_object_id,version) \
                  SELECT disruption_id,pt_object_id,OLD.version FROM public.associate_disruption_pt_object WHERE disruption_id = OLD.id; \
-                 INSERT INTO history.associate_disruption_property(disruption_id,property_id,version) \
-                 SELECT disruption_id,property_id,OLD.version FROM public.associate_disruption_property WHERE disruption_id = OLD.id; \
+                 INSERT INTO history.associate_disruption_property(value,disruption_id,property_id,version) \
+                 SELECT value,disruption_id,property_id,OLD.version FROM public.associate_disruption_property WHERE disruption_id = OLD.id; \
                  RETURN NEW; \
                 END; \
                 $BODY$\

--- a/migrations/versions/cf4581a9123_init_history_schema.py
+++ b/migrations/versions/cf4581a9123_init_history_schema.py
@@ -14,8 +14,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-status_type = sa.Enum('waiting', 'handling', 'error', 'done', name='status')
-
 def upgrade():
     op.execute('CREATE SCHEMA IF NOT EXISTS history')
     op.create_table('disruption',
@@ -27,7 +25,6 @@ def upgrade():
                     sa.Column('note', sa.Text(), nullable=True),
                     sa.Column('start_publication_date', sa.DateTime(), nullable=True),
                     sa.Column('end_publication_date', sa.DateTime(), nullable=True),
-                    sa.Column('localization_id', sa.TEXT(), nullable=True),
                     sa.Column('version', sa.Integer(), nullable=False),
                     sa.Column('client_id', postgresql.UUID(), nullable=False),
                     sa.Column('contributor_id', postgresql.UUID(), nullable=False),
@@ -43,15 +40,14 @@ def upgrade():
                  IF NEW.reference <> OLD.reference OR NEW.note <> OLD.note \
                     OR NEW.start_publication_date <> OLD.start_publication_date \
                     OR NEW.end_publication_date <> OLD.end_publication_date \
-                    OR NEW.localization_id <> OLD.localization_id \
                     OR NEW.client_id <> OLD.client_id OR NEW.contributor_id <> OLD.contributor_id \
                     OR NEW.cause_id <> OLD.cause_id OR NEW.status <> OLD.status \
                     THEN \
                  INSERT INTO history.disruption(created_at,updated_at,disruption_id,reference,note,\
-                    start_publication_date,end_publication_date,localization_id,version,client_id,contributor_id,\
+                    start_publication_date,end_publication_date,version,client_id,contributor_id,\
                     cause_id,status) \
                  VALUES(OLD.created_at,OLD.updated_at,OLD.id,OLD.reference,OLD.note,OLD.start_publication_date,\
-                    OLD.end_publication_date,OLD.localization_id,OLD.version,OLD.client_id,OLD.contributor_id,\
+                    OLD.end_publication_date,OLD.version,OLD.client_id,OLD.contributor_id,\
                     OLD.cause_id,OLD.status); \
                  END IF; \
                  RETURN NEW; \

--- a/migrations/versions/cf4581a9123_init_history_schema.py
+++ b/migrations/versions/cf4581a9123_init_history_schema.py
@@ -1,0 +1,72 @@
+"""Init history schema
+
+Revision ID: cf4581a9123
+Revises: bf4581a9122
+Create Date: 2019-04-17 16:59:47.907869
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'cf4581a9123'
+down_revision = 'bf4581a9122'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+status_type = sa.Enum('waiting', 'handling', 'error', 'done', name='status')
+
+def upgrade():
+    op.execute('CREATE SCHEMA IF NOT EXISTS history')
+    op.create_table('disruption',
+                    sa.Column('created_at', sa.DateTime(), nullable=False),
+                    sa.Column('updated_at', sa.DateTime(), nullable=True),
+                    sa.Column('id', sa.Integer(), nullable=False, autoincrement=True),
+                    sa.Column('disruption_id', postgresql.UUID(), nullable=False),
+                    sa.Column('reference', sa.Text(), nullable=True),
+                    sa.Column('note', sa.Text(), nullable=True),
+                    sa.Column('start_publication_date', sa.DateTime(), nullable=True),
+                    sa.Column('end_publication_date', sa.DateTime(), nullable=True),
+                    sa.Column('localization_id', sa.TEXT(), nullable=True),
+                    sa.Column('version', sa.Integer(), nullable=False),
+                    sa.Column('client_id', postgresql.UUID(), nullable=False),
+                    sa.Column('contributor_id', postgresql.UUID(), nullable=False),
+                    sa.Column('cause_id', postgresql.UUID(), nullable=False),
+                    sa.Column('status', sa.Text(), nullable=False),
+                    sa.PrimaryKeyConstraint('id'),
+                    schema='history'
+                    )
+    op.execute('CREATE OR REPLACE FUNCTION log_disruption_update() \
+                  RETURNS trigger AS \
+                $BODY$ \
+                BEGIN \
+                 IF NEW.reference <> OLD.reference OR NEW.note <> OLD.note \
+                    OR NEW.start_publication_date <> OLD.start_publication_date \
+                    OR NEW.end_publication_date <> OLD.end_publication_date \
+                    OR NEW.localization_id <> OLD.localization_id \
+                    OR NEW.client_id <> OLD.client_id OR NEW.contributor_id <> OLD.contributor_id \
+                    OR NEW.cause_id <> OLD.cause_id OR NEW.status <> OLD.status \
+                    THEN \
+                 INSERT INTO history.disruption(created_at,updated_at,disruption_id,reference,note,\
+                    start_publication_date,end_publication_date,localization_id,version,client_id,contributor_id,\
+                    cause_id,status) \
+                 VALUES(OLD.created_at,OLD.updated_at,OLD.id,OLD.reference,OLD.note,OLD.start_publication_date,\
+                    OLD.end_publication_date,OLD.localization_id,OLD.version,OLD.client_id,OLD.contributor_id,\
+                    OLD.cause_id,OLD.status); \
+                 END IF; \
+                 RETURN NEW; \
+                END; \
+                $BODY$\
+                LANGUAGE plpgsql VOLATILE')
+    op.execute('CREATE TRIGGER last_disruption_changes \
+              BEFORE UPDATE \
+              ON public.disruption \
+              FOR EACH ROW \
+              EXECUTE PROCEDURE log_disruption_update();')
+
+
+def downgrade():
+    op.execute('DROP TRIGGER last_disruption_changes')
+    op.execute('DROP FUNCTION IF EXISTS log_disruption_update')
+    op.drop_table('disruption')
+    op.execute('DROP SCHEMA IF EXISTS history')

--- a/tests/features/list-disruption-history.feature
+++ b/tests/features/list-disruption-history.feature
@@ -1,0 +1,127 @@
+Feature: disruption history
+    Background:
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "X-Contributors" with "contrib1"
+    Scenario: List of an updated disruption
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                              | client_id                            | contributor_id                       |version|
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |1|
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following tags in my database:
+            | name      |  created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   |  2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 5ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | strike    |  2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 5ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the relation associate_disruption_tag in my database:
+            | tag_id                               | disruption_id                        |
+            | 5ffab230-3d48-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3 |
+        Given I have the following properties in my database:
+            | created_at          | id                                   | client_id                            | key    | type   |
+            | 2014-04-02T23:52:12 | e408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | key    | type   |
+            | 2014-04-02T23:52:12 | f408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | test   | test   |
+        Given I have the following ptobject in my database:
+            | type     | uri                    | created_at          | updated_at          | id                                         |
+            | stop_area| stop_area:JDR:SA:CHVIN | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area| stop_area:JDR:SA:BASTI | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 2ffab232-3d48-4eea-aa2c-22f8680230b6       |
+        Given I have the following associate_disruption_properties in my database:
+            | value | disruption_id                        | property_id                          |
+            | val1  | a750994c-01fe-11e4-b4fb-080027079ff3 | e408adec-0243-11e6-954b-0050568c8382 |
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3" with:
+        """
+        {"reference":"foo2", "contributor": "contrib1", "properties":[], "cause":{"id":"7bfab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.version" should be "2"
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3" with:
+        """
+        {"reference":"foo2", "contributor": "contrib1", "properties":[], "localization":[{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}], "cause":{"id":"7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-15T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.version" should be "3"
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3" with:
+        """
+        {"reference":"foo3", "contributor": "contrib1", "note":"note1", "properties":[{"property_id":"e408adec-0243-11e6-954b-0050568c8382", "value":"val1"},{"property_id":"f408adec-0243-11e6-954b-0050568c8382", "value":"val2"}], "tags":[{"id":"5ffab232-3d48-4eea-aa2c-22f8680230b6"}], "cause":{"id":"7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-15T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.version" should be "4"
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3" with:
+        """
+        {"reference":"foo3", "contributor": "contrib1", "properties":[], "localization":[{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, {"id":"stop_area:JDR:SA:BASTI", "type":"stop_area"}], "tags":[{"id":"5ffab230-3d48-4eea-aa2c-22f8680230b6"},{"id":"5ffab232-3d48-4eea-aa2c-22f8680230b6"}], "cause":{"id":"7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-15T13:50:00Z","end":"2019-01-10T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "network:JDR:1","type": "network"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.version" should be "5"
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 5
+        And the field "disruptions.0.reference" should be "foo"
+        And the field "disruptions.0.note" should be "hello"
+        And the field "disruptions.0.cause.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.0.publication_period.begin" should be "2018-09-11T13:50:00Z"
+        And the field "disruptions.0.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.0.localization" should have a size of 0
+        And the field "disruptions.0.properties" should have a size of 1
+        And the field "disruptions.0.properties.type.0.property.id" should be "e408adec-0243-11e6-954b-0050568c8382"
+        And the field "disruptions.0.properties.type.0.value" should be "val1"
+        And the field "disruptions.0.tags" should have a size of 1
+        And the field "disruptions.0.tags.0.name" should be "weather"
+        And the field "disruptions.0.version" should be "1"
+        And the field "disruptions.1.reference" should be "foo2"
+        And the field "disruptions.1.note" should be null
+        And the field "disruptions.1.cause.id" should be "7bfab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.publication_period.begin" should be "2018-09-11T13:50:00Z"
+        And the field "disruptions.1.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.1.properties" should have a size of 0
+        And the field "disruptions.1.localization" should have a size of 0
+        And the field "disruptions.1.tags" should have a size of 0
+        And the field "disruptions.1.version" should be "2"
+        And the field "disruptions.2.reference" should be "foo2"
+        And the field "disruptions.2.note" should be null
+        And the field "disruptions.2.cause.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.2.publication_period.begin" should be "2018-09-15T13:50:00Z"
+        And the field "disruptions.2.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.2.properties" should have a size of 0
+        And the field "disruptions.2.localization" should have a size of 1
+        And the field "disruptions.2.localization.0.id" should be "stop_area:JDR:SA:CHVIN"
+        And the field "disruptions.2.tags" should have a size of 0
+        And the field "disruptions.2.version" should be "3"
+        And the field "disruptions.3.reference" should be "foo3"
+        And the field "disruptions.3.note" should be "note1"
+        And the field "disruptions.3.cause.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.3.publication_period.begin" should be "2018-09-15T13:50:00Z"
+        And the field "disruptions.3.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.3.properties" should have a size of 2
+        And the field "disruptions.3.properties.type.0.property.id" should be "e408adec-0243-11e6-954b-0050568c8382"
+        And the field "disruptions.3.properties.type.0.value" should be "val1"
+        And the field "disruptions.3.properties.test.0.property.id" should be "f408adec-0243-11e6-954b-0050568c8382"
+        And the field "disruptions.3.properties.test.0.value" should be "val2"
+        And the field "disruptions.3.localization" should have a size of 0
+        And the field "disruptions.3.tags" should have a size of 1
+        And the field "disruptions.3.tags.0.name" should be "strike"
+        And the field "disruptions.3.version" should be "4"
+        And the field "disruptions.4.reference" should be "foo3"
+        And the field "disruptions.4.note" should be null
+        And the field "disruptions.4.cause.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.4.publication_period.begin" should be "2018-09-15T13:50:00Z"
+        And the field "disruptions.4.publication_period.end" should be "2019-01-10T16:50:00Z"
+        And the field "disruptions.4.properties" should have a size of 0
+        And the field "disruptions.4.localization" should have a size of 2
+        And the field "disruptions.4.tags" should have a size of 2
+        And the field "disruptions.4.version" should be "5"

--- a/tests/features/terrain.py
+++ b/tests/features/terrain.py
@@ -34,7 +34,10 @@ def teardown_db(feature):
 def truncate_db(scenario):
     with chaos.app.app_context():
         tables = [str(table) for table in chaos.db.metadata.sorted_tables]
+        history_tables = chaos.db.session.execute('SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = \'history\';').fetchall()
         chaos.db.session.execute('TRUNCATE {} CASCADE;'.format(', '.join(tables)))
+        chaos.db.session.commit()
+        chaos.db.session.execute('TRUNCATE {} CASCADE;'.format(', '.join('history.'+table[0] for table in history_tables)))
         chaos.db.session.commit()
 
 


### PR DESCRIPTION
# Description

This add the route /disruptions/{UIID}/history and return a versionnning list of the disruption (just the modification of the disruption -> not the impacts) 

## Issue

Issue link: BOT-1311

## How to test

Here are the following steps to test this pull request:

- Create then change the disruption properties (multi-time)
- Call the API with /disruptions/{UIID}/history
- You should see all modification except for the impacts parts

## AT

|Given|When|Then|
|---|---|---|
|J'ai créé une perturbation|Je consulte l'historique de cette perturbation|J'ai une liste avec 1 seule entrée, l'état actuel de la perturbation et sa date de création|
|Je modifie la cause de cette perturbation|Je consulte l'historique de cette perturbation|J'ai une liste avec 2 entrées, la première entrée est l'état de création, et la deuxième entrée est l'état actuel avec leur date de modification (Chaque entrée correspond à une perturbation complète)|
|J'ai la même perturbation où je ne change rien mais je "put" dans la base|Je consulte l'historique de cette perturbation|J'ai une liste avec 3 entrées (changement de comportement à prévoir)|
|J'ai des perturbations qui existent avant le développement de cette feature|Je consulte l'historique de cette perturbation|J'ai une liste avec 1 seule entrée, l'état actuel de la perturbation avec son numéro de version et sa dernière date de modification|
|J'ai modifié une perturbation|Je consulte la perturbation dans Navitia|Je ne vois que la dernière version|
|J'ai une perturbation|Je consulte la liste d'historique de ma perturbation|Je vois l'historique avec une section pagination|

## Team reviewers

- [x] Dev
- [x] QA