### PR TITLE
Fix return carriage of html messages

### DIFF
--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -29,7 +29,6 @@
 
 from chaos import models, exceptions, mapper, db
 from utils import get_application_periods
-import logging
 
 
 def fill_and_get_pt_object(navitia, all_objects, json, add_to_db=True):

--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -210,8 +210,8 @@ def fill_and_add_line_section(navitia, impact_id, all_objects, pt_object_json):
     ptobject.insert_line_section(line_section)
     return ptobject
 
-def clean_message(msg):
-    if msg.channel.content_type == 'text/html':
+def clean_message(msg, type=''):
+    if type == 'text/html':
         msg.text = msg.text.replace('\r\n', '')
 
 def manage_message(impact, json, client_id):
@@ -224,13 +224,14 @@ def manage_message(impact, json, client_id):
             if message_json["channel"]["id"] in messages_db:
                 msg = messages_db[message_json["channel"]["id"]]
                 mapper.fill_from_json(msg, message_json, mapper.message_mapping)
-                clean_message(msg)
+                clean_message(msg,  msg.channel.content_type)
                 manage_message_meta(msg, message_json)
             else:
                 message = models.Message()
                 message.impact_id = impact.id
                 mapper.fill_from_json(message, message_json, mapper.message_mapping)
-                clean_message(message)
+                channel = models.Channel.get(message.channel_id, client_id)
+                clean_message(message, channel.content_type)
                 impact.insert_message(message)
                 manage_message_meta(message, message_json)
                 messages_db[message.channel_id] = message

--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -212,7 +212,7 @@ def fill_and_add_line_section(navitia, impact_id, all_objects, pt_object_json):
 
 def clean_message(msg, type=''):
     if type == 'text/html':
-        msg.text = msg.text.replace('\r\n', '')
+        msg.text = msg.text.replace('\r\n', ' ')
 
 def manage_message(impact, json, client_id):
     messages_db = dict((msg.channel_id, msg) for msg in impact.messages)

--- a/migrations/versions/d57921a3453_update_carriage_return.py
+++ b/migrations/versions/d57921a3453_update_carriage_return.py
@@ -19,3 +19,4 @@ def upgrade():
 
 def downgrade():
     # function needed but not necessary for downgrade this fix
+    pass

--- a/migrations/versions/d57921a3453_update_carriage_return.py
+++ b/migrations/versions/d57921a3453_update_carriage_return.py
@@ -11,10 +11,11 @@ revision = 'd57921a3453'
 down_revision = 'cf4581a9123'
 
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 def upgrade():
     op.execute('UPDATE message SET text = regexp_replace(text, E\'[\\\\n\\\\r]\', \'\', \'g\' ) \
                 FROM channel \
                 WHERE message.channel_id = channel.id AND channel.content_type = \'text/html\';')
+
+def downgrade():
+    # function needed but not necessary for downgrade this fix

--- a/migrations/versions/d57921a3453_update_carriage_return.py
+++ b/migrations/versions/d57921a3453_update_carriage_return.py
@@ -1,0 +1,20 @@
+"""Update carriage return on HTML messages
+
+Revision ID: d57921a3453
+Revises: cf4581a9123
+Create Date: 2019-04-24 17:05:02
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd57921a3453'
+down_revision = 'cf4581a9123'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.execute('UPDATE message SET text = regexp_replace(text, E\'[\\\\n\\\\r]\', \'\', \'g\' ) \
+                FROM channel \
+                WHERE message.channel_id = channel.id AND channel.content_type = \'text/html\';')


### PR DESCRIPTION
# Description

This PR fix the problem of html messages that was copied from word

## Issue

Issue link: BOT-1167

## Pull Request type

This is a bug fix

## How to test

Here are the following steps to test this pull request:

- copy from a word doc into an html message of an impact
- get the message from chaos api
- you shouldn't see \r\n in the text return

