### PR TITLE
Adding version number in disruption history in order to use them as additional sorting column

### DIFF
--- a/chaos/history.py
+++ b/chaos/history.py
@@ -7,10 +7,11 @@ from aniso8601 import parse_datetime, parse_time, parse_date
 from chaos import db, models
 
 
-def save_in_database(disruption_id, disruption_json):
+def save_disruption(disruption, disruption_json):
     history_disruption = models.HistoryDisruption()
 
-    history_disruption.disruption_id = disruption_id
+    history_disruption.disruption_id = disruption.id
+    history_disruption.version = disruption.version
     history_disruption.data = disruption_json
     db.session.add(history_disruption)
     db.session.commit()
@@ -37,7 +38,7 @@ def save_disruption_in_history(data):
 
     clean_before_save_in_history(disruption)
     disruption['impacts'] = disruption['impacts']['impacts']
-    save_in_database(data.id, json.dumps(disruption))
+    save_disruption(data, json.dumps(disruption))
 
 
 def get_datetime_from_json_attr(json, attr):

--- a/chaos/models.py
+++ b/chaos/models.py
@@ -2253,6 +2253,7 @@ class HistoryDisruption(db.Model):
     created_at = db.Column(db.DateTime(), default=get_current_time, nullable=False)
     disruption_id = db.Column(UUID, db.ForeignKey(Disruption.id))
     data = db.Column(db.Text, unique=False, nullable=False)
+    version = db.Column(db.Integer, nullable=False, default=1)
 
     def __repr__(self):
         return '<HistoryDisruption %r>' % self.id
@@ -2262,4 +2263,4 @@ class HistoryDisruption(db.Model):
 
     @classmethod
     def get_by_disruption_id(cls, disruption_id):
-        return cls.query.filter_by(disruption_id=disruption_id).order_by(desc(cls.created_at))
+        return cls.query.filter_by(disruption_id=disruption_id).order_by(desc(cls.created_at), desc(cls.version))

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1550,6 +1550,7 @@ class Impacts(flask_restful.Resource):
             if not chaos.utils.send_disruption_to_navitia(disruption):
                 ex_msg = 'An error occurred during transferring this impact to Navitia. Please try again'
                 raise exceptions.NavitiaError(ex_msg)
+            save_disruption_in_history(disruption)
             return marshal({'impact': impact}, one_impact_fields), 201
         except exceptions.NavitiaError as e:
             db.session.delete(impact)
@@ -1604,6 +1605,7 @@ this impact to Navitia. Please try again.'}}, error_fields), 503
                 {'error': {'message': '{}'.format(e.message)}},
                 error_fields
             ), 500
+        save_disruption_in_history(disruption)
         return marshal({'impact': impact}, one_impact_fields), 200
 
     @validate_contributor()

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1622,6 +1622,7 @@ this impact to Navitia. Please try again.'}}, error_fields), 503
             if chaos.utils.send_disruption_to_navitia(disruption):
                 db.session.commit()
                 db.session.refresh(disruption)
+                save_disruption_in_history(disruption)
                 return None, 204
             else:
                 db.session.rollback()

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -8,7 +8,7 @@
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-
+script_location = ./
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/migrations/versions/192476718432_adding_disruption_version_in_history.py
+++ b/migrations/versions/192476718432_adding_disruption_version_in_history.py
@@ -1,0 +1,22 @@
+"""Adding disruption version in history
+
+Revision ID: 192476718432
+Revises: 50f90e14e248
+Create Date: 2019-06-04 16:58:11.378712
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '192476718432'
+down_revision = '50f90e14e248'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('disruption', sa.Column('version', sa.Integer(), nullable=False, server_default='1'), schema='history')
+
+
+def downgrade():
+    op.drop_column('disruption', 'version', schema='history')

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -128,3 +128,52 @@ Feature: disruption with impacts history
         And the field "disruptions.0.impacts.impacts" should have a size of 1
         And the field "disruptions.0.impacts.impacts.0.objects" should have a size of 1
         And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "line:JDR:RER-B"
+
+
+    Scenario: List of an updated disruption with delete impact
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff5 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                         |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | a750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b2 | a750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I delete to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b1" with:
+        Then the status code should be "204"
+
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I delete to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab234-3d49-4eea-aa2c-22f8680230b2" with:
+        Then the status code should be "204"
+
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.status" should be "archived"

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -79,6 +79,11 @@ Feature: disruption with impacts history
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 3
+        And the field "disruptions.0.impacts.impacts" should have a size of 2
+        And the field "disruptions.0.impacts.impacts.0.objects" should have a size of 1
+        And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "network:JDR:2"
+        And the field "disruptions.0.impacts.impacts.1.objects" should have a size of 1
+        And the field "disruptions.0.impacts.impacts.1.objects.0.id" should be "line:JDR:M1"
 
 
 

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -1,10 +1,12 @@
 Feature: disruption with impacts history
+
     Background:
+
         I fill in header "X-Customer-Id" with "5"
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-    Scenario: List of an updated disruption with put impact
+
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
@@ -15,12 +17,15 @@ Feature: disruption with impacts history
         Given I have the following contributors in my database:
             | contributor_code   | created_at          | updated_at          | id                                   |
             | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-        Given I have the following disruptions in my database:
-            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
-            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
         Given I have the following severities in my database:
             | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
             | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+  Scenario: List of an updated disruption with impact put
+
+      Given I have the following disruptions in my database:
+        | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
+        | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
         Given I have the following ptobject in my database:
             | type     | uri                    | created_at          | updated_at          | id                                         |
             | stop_area| stop_area:JDR:SA:CHVIN | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
@@ -56,13 +61,8 @@ Feature: disruption with impacts history
 
         Given I have the following impacts in my database:
             | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 4ffab232-3d48-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3|7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 4ffab232-3d48-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
-
-        I fill in header "X-Customer-Id" with "5"
-        I fill in header "X-Contributors" with "contrib1"
-        I fill in header "X-Coverage" with "jdr"
-        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
         When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts/4ffab232-3d48-4eea-aa2c-22f8680230b6" with:
 
         """
@@ -88,28 +88,14 @@ Feature: disruption with impacts history
         And the field "disruptions.1.impacts.impacts.0.objects" should have a size of 1
         And the field "disruptions.1.impacts.impacts.0.objects.0.id" should be "line:JDR:M1"
 
-    Scenario: List of an updated disruption with post impact
-        Given I have the following clients in my database:
-            | client_code   | created_at          | updated_at          | id                                   |
-            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-        Given I have the following causes in my database:
-            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
-            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-        Given I have the following contributors in my database:
-            | contributor_code   | created_at          | updated_at          | id                                   |
-            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+    Scenario: List an updated disruption with impact posted
+
         Given I have the following disruptions in my database:
             | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
             | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff4 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
-        Given I have the following severities in my database:
-            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
-            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-        I fill in header "X-Customer-Id" with "5"
-        I fill in header "X-Contributors" with "contrib1"
-        I fill in header "X-Coverage" with "jdr"
-        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+
+
         When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff4/impacts" with:
         """
         {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "line:JDR:RER-B","type": "line"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
@@ -130,49 +116,29 @@ Feature: disruption with impacts history
         And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "line:JDR:RER-B"
 
 
-    Scenario: List of an updated disruption with delete impact
-        Given I have the following clients in my database:
-            | client_code   | created_at          | updated_at          | id                                   |
-            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-        Given I have the following causes in my database:
-            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
-            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-        Given I have the following contributors in my database:
-            | contributor_code   | created_at          | updated_at          | id                                   |
-            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+    Scenario: List an updated disruption with impacts deleted
+
         Given I have the following disruptions in my database:
             | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
-            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff5 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
-        Given I have the following severities in my database:
-            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
-            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | b750994c-01fe-11e4-b4fb-080027079ff5 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
         Given I have the following impacts in my database:
             | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                         |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | a750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b2 | a750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | b750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b2 | b750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
-        I fill in header "X-Customer-Id" with "5"
-        I fill in header "X-Contributors" with "contrib1"
-        I fill in header "X-Coverage" with "jdr"
-        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I delete to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b1" with:
+        When I delete to "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b1" with:
         Then the status code should be "204"
 
-        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/history"
+        When I get "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/history"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
         And the field "disruptions.0.impacts.impacts" should have a size of 1
 
-        I fill in header "X-Customer-Id" with "5"
-        I fill in header "X-Contributors" with "contrib1"
-        I fill in header "X-Coverage" with "jdr"
-        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-        When I delete to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab234-3d49-4eea-aa2c-22f8680230b2" with:
+        When I delete to "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab234-3d49-4eea-aa2c-22f8680230b2" with:
         Then the status code should be "204"
 
-        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff5/history"
+        When I get "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/history"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 2

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -4,7 +4,7 @@ Feature: disruption with impacts history
         I fill in header "X-Contributors" with "contrib1"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-    Scenario: List of an updated disruption with one impact
+    Scenario: List of an updated disruption with put impact
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
@@ -84,6 +84,47 @@ Feature: disruption with impacts history
         And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "network:JDR:2"
         And the field "disruptions.0.impacts.impacts.1.objects" should have a size of 1
         And the field "disruptions.0.impacts.impacts.1.objects.0.id" should be "line:JDR:M1"
+        And the field "disruptions.1.impacts.impacts" should have a size of 1
+        And the field "disruptions.1.impacts.impacts.0.objects" should have a size of 1
+        And the field "disruptions.1.impacts.impacts.0.objects.0.id" should be "line:JDR:M1"
 
+    Scenario: List of an updated disruption with post impact
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff4 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff4/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "line:JDR:RER-B","type": "line"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+        Then the status code should be "201"
+        And the header "Content-Type" should be "application/json"
+        And the field "impact.objects" should exist
+        And the field "impact.objects" should have a size of 1
+        And the field "impact.objects.0.id" should be "line:JDR:RER-B"
+        And the field "impact.objects.0.type" should be "line"
 
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff4/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 1
+        And the field "disruptions.0.impacts.impacts" should have a size of 1
+        And the field "disruptions.0.impacts.impacts.0.objects" should have a size of 1
+        And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "line:JDR:RER-B"

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -124,7 +124,7 @@ Feature: disruption with impacts history
         Given I have the following impacts in my database:
             | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                         |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | b750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b2 | b750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:53:13 | 2014-04-06T20:50:10 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b2 | b750994c-01fe-11e4-b4fb-080027079ff5 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
         When I delete to "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b1" with:
         Then the status code should be "204"
@@ -134,6 +134,13 @@ Feature: disruption with impacts history
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 1
         And the field "disruptions.0.impacts.impacts" should have a size of 1
+        # some lines to slow down test
+        # TODO improve history sort order
+        And the field "disruptions.0.impacts.impacts.0.id" should be "7ffab234-3d49-4eea-aa2c-22f8680230b2"
+        And the field "disruptions.0.impacts.impacts.0.disruption.href" should contain "b750994c-01fe-11e4-b4fb-080027079ff5"
+        And the field "disruptions.0.impacts.impacts.0.created_at" should be "2014-04-04T23:53:13Z"
+        And the field "disruptions.0.impacts.impacts.0.updated_at" should be "2014-04-06T20:50:10Z"
+        And the field "disruptions.0.impacts.impacts.0.severity.id" should be "7ffab232-3d48-4eea-aa2c-22f8680230b6"
 
         When I delete to "/disruptions/b750994c-01fe-11e4-b4fb-080027079ff5/impacts/7ffab234-3d49-4eea-aa2c-22f8680230b2" with:
         Then the status code should be "204"

--- a/tests/features/list-disruption-with-impacts-history.feature
+++ b/tests/features/list-disruption-with-impacts-history.feature
@@ -1,0 +1,84 @@
+Feature: disruption with impacts history
+    Background:
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+    Scenario: List of an updated disruption with one impact
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | cause1    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | cause2    | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7bfab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                               | client_id                            | contributor_id                         |version|
+            | foo       | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2018-09-11T13:50:00    | 2018-12-31T16:50:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6   | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6   |1      |
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following ptobject in my database:
+            | type     | uri                    | created_at          | updated_at          | id                                         |
+            | stop_area| stop_area:JDR:SA:CHVIN | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area| stop_area:JDR:SA:BASTI | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 2ffab232-3d48-4eea-aa2c-22f8680230b6       |
+        Given I have the following history_disruption in my database:
+            | id | disruption_id  | data        | created_at          |
+            | 8ffab555-3d48-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3 | {"status": "published", "created_at": "2014-04-02T23:52:12Z", "impacts": [{"created_at": "2019-05-27T09:44:50Z", "updated_at": null, "disruption": {}, "objects": [{"type": "network", "id": "network:JDR:1", "name": "RATP"}], "id": "121fd37d-8064-11e9-9e35-34e6d748c530", "severity": {"color": "#654321", "created_at": "2014-04-04T23:52:12Z", "effect": "unknown_effect", "updated_at": "2014-04-06T22:52:12Z", "priority": null, "wordings": [], "id": "7ffab232-3d48-4eea-aa2c-22f8680230b6", "wording": "good news"}, "messages": [], "send_notifications": false, "notification_date": null, "application_period_patterns": [], "application_periods": [{"begin": "2014-04-29T16:52:00Z", "end": "2014-06-22T02:15:00Z"}]}], "reference": "foo", "publication_status": "past", "publication_period": {"begin": "2018-09-11T13:50:00Z", "end": "2018-12-31T16:50:00Z"}, "localization": [], "updated_at": "2019-05-27T09:44:50Z", "properties": {"property_type_1": [{"property": {"updated_at": null, "id": "e408adec-0243-11e6-954b-0050568c8382", "key": "key", "type": "type", "created_at": "2019-05-28T13:46:57Z"}, "value": "val1"}]}, "note": "", "version": 1, "contributor": "contrib1", "cause": {"category": null, "updated_at": "2014-04-02T23:55:12Z", "id": "7ffab230-3d48-4eea-aa2c-22f8680230b6", "wordings": [], "created_at": "2014-04-02T23:52:12Z"}, "id": "a750994c-01fe-11e4-b4fb-080027079ff3", "tags":[]} | 2014-04-02T23:52:12 |
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3" with:
+        """
+        {"reference":"foo2", "contributor": "contrib1", "properties":[], "cause":{"id":"7bfab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"},"objects": [{"id": "line:JDR:M1","type": "line"}],"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}]}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.version" should be "2"
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 2
+        And the field "disruptions.0.reference" should be "foo2"
+        And the field "disruptions.0.cause.id" should be "7bfab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.0.publication_period.begin" should be "2018-09-11T13:50:00Z"
+        And the field "disruptions.0.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.0.version" should be "2"
+        And the field "disruptions.0.impacts.impacts" should exist
+        And the field "disruptions.0.impacts.impacts.0.objects.0.id" should be "line:JDR:M1"
+        And the field "disruptions.1.reference" should be "foo"
+        And the field "disruptions.1.cause.id" should be "7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        And the field "disruptions.1.publication_period.begin" should be "2018-09-11T13:50:00Z"
+        And the field "disruptions.1.publication_period.end" should be "2018-12-31T16:50:00Z"
+        And the field "disruptions.1.version" should be "1"
+        And the field "disruptions.1.impacts.impacts" should exist
+        And the field "disruptions.1.impacts.impacts.0.objects.0.id" should be "network:JDR:1"
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 4ffab232-3d48-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3|7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts/4ffab232-3d48-4eea-aa2c-22f8680230b6" with:
+
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "network:JDR:2","type": "network"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "impact.objects" should have a size of 1
+        And the field "impact.objects.0.id" should be "network:JDR:2"
+        And the field "impact.objects.0.type" should be "network"
+
+        When I get "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/history"
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruptions" should have a size of 3
+
+
+


### PR DESCRIPTION
# Description

This PR fixes disruptions order in history

:warning:  do db migration  