### PR TITLE
Feature bot 749 message arrays required

### DIFF
--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -50,7 +50,7 @@ import logging
 from utils import make_pager, option_value, get_current_time, add_notification_date_on_impacts
 from chaos.validate_params import validate_client, validate_contributor, validate_navitia, \
     manage_navitia_error, validate_id, validate_client_token, validate_send_notifications_and_notification_date, \
-    validate_required_arrays
+    validate_required_list_of_impact
 from collections import OrderedDict
 from aniso8601 import parse_datetime
 from history import save_disruption_in_history, create_disruption_from_json
@@ -301,7 +301,7 @@ class Disruptions(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
-    @validate_required_arrays()
+    @validate_required_list_of_impact()
     def post(self, client, navitia):
         self.navitia = navitia
         json = request.get_json(silent=True)
@@ -379,7 +379,7 @@ class Disruptions(flask_restful.Resource):
     @validate_id(True)
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
-    @validate_required_arrays()
+    @validate_required_list_of_impact()
     def put(self, client, contributor, navitia, id):
         self.navitia = navitia
         disruption = models.Disruption.get(id, contributor.id)
@@ -1520,7 +1520,7 @@ class Impacts(flask_restful.Resource):
     @validate_navitia()
     @manage_navitia_error()
     @validate_send_notifications_and_notification_date()
-    @validate_required_arrays()
+    @validate_required_list_of_impact()
     def post(self, client, contributor, navitia, disruption_id):
         self.navitia = navitia
         if not id_format.match(disruption_id):
@@ -1573,7 +1573,7 @@ class Impacts(flask_restful.Resource):
     @manage_navitia_error()
     @validate_id(True)
     @validate_send_notifications_and_notification_date()
-    @validate_required_arrays()
+    @validate_required_list_of_impact()
     def put(self, client, contributor, navitia, disruption_id, id):
         self.navitia = navitia
         json = request.get_json(silent=True)

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -49,7 +49,8 @@ from sqlalchemy.exc import IntegrityError
 import logging
 from utils import make_pager, option_value, get_current_time, add_notification_date_on_impacts
 from chaos.validate_params import validate_client, validate_contributor, validate_navitia, \
-    manage_navitia_error, validate_id, validate_client_token, validate_send_notifications_and_notification_date
+    manage_navitia_error, validate_id, validate_client_token, validate_send_notifications_and_notification_date, \
+    validate_required_arrays
 from collections import OrderedDict
 from aniso8601 import parse_datetime
 from history import save_disruption_in_history, create_disruption_from_json
@@ -300,6 +301,7 @@ class Disruptions(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
+    @validate_required_arrays()
     def post(self, client, navitia):
         self.navitia = navitia
         json = request.get_json(silent=True)
@@ -377,6 +379,7 @@ class Disruptions(flask_restful.Resource):
     @validate_id(True)
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
+    @validate_required_arrays()
     def put(self, client, contributor, navitia, id):
         self.navitia = navitia
         disruption = models.Disruption.get(id, contributor.id)
@@ -1517,6 +1520,7 @@ class Impacts(flask_restful.Resource):
     @validate_navitia()
     @manage_navitia_error()
     @validate_send_notifications_and_notification_date()
+    @validate_required_arrays()
     def post(self, client, contributor, navitia, disruption_id):
         self.navitia = navitia
         if not id_format.match(disruption_id):
@@ -1569,6 +1573,7 @@ class Impacts(flask_restful.Resource):
     @manage_navitia_error()
     @validate_id(True)
     @validate_send_notifications_and_notification_date()
+    @validate_required_arrays()
     def put(self, client, contributor, navitia, disruption_id, id):
         self.navitia = navitia
         json = request.get_json(silent=True)

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -50,7 +50,7 @@ import logging
 from utils import make_pager, option_value, get_current_time, add_notification_date_on_impacts
 from chaos.validate_params import validate_client, validate_contributor, validate_navitia, \
     manage_navitia_error, validate_id, validate_client_token, validate_send_notifications_and_notification_date, \
-    validate_required_list_of_impact
+    validate_impact_lists
 from collections import OrderedDict
 from aniso8601 import parse_datetime
 from history import save_disruption_in_history, create_disruption_from_json
@@ -301,7 +301,7 @@ class Disruptions(flask_restful.Resource):
     @manage_navitia_error()
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
-    @validate_required_list_of_impact()
+    @validate_impact_lists()
     def post(self, client, navitia):
         self.navitia = navitia
         json = request.get_json(silent=True)
@@ -379,7 +379,7 @@ class Disruptions(flask_restful.Resource):
     @validate_id(True)
     @validate_client_token()
     @validate_send_notifications_and_notification_date()
-    @validate_required_list_of_impact()
+    @validate_impact_lists()
     def put(self, client, contributor, navitia, id):
         self.navitia = navitia
         disruption = models.Disruption.get(id, contributor.id)
@@ -1520,7 +1520,7 @@ class Impacts(flask_restful.Resource):
     @validate_navitia()
     @manage_navitia_error()
     @validate_send_notifications_and_notification_date()
-    @validate_required_list_of_impact()
+    @validate_impact_lists()
     def post(self, client, contributor, navitia, disruption_id):
         self.navitia = navitia
         if not id_format.match(disruption_id):
@@ -1573,7 +1573,7 @@ class Impacts(flask_restful.Resource):
     @manage_navitia_error()
     @validate_id(True)
     @validate_send_notifications_and_notification_date()
-    @validate_required_list_of_impact()
+    @validate_impact_lists()
     def put(self, client, contributor, navitia, disruption_id, id):
         self.navitia = navitia
         json = request.get_json(silent=True)

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -187,34 +187,27 @@ class validate_impact_lists(object):
         def wrapper(*args, **kwargs):
             json = request.get_json(silent=True)
             impacts = []
-            if json and 'impacts' in json:
+
+            # in disruption
+            if json and 'impacts' in json:  # json is disruption
                 impacts = json['impacts']
                 if not impacts:
                     return marshal(
                         {'error': {'message': "impacts should not be empty"}},
                         fields.error_fields
                     ), 400
-            elif json and 'severity' in json:
+            elif json and 'severity' in json:  # json is impact
                 impacts = [json]
-            for impact in impacts:
-                if ('objects' in impact) and not impact['objects']:
-                    return marshal(
-                        {'error': {'message': "objects should not be empty"}},
-                        fields.error_fields
-                    ), 400
-                elif ('application_periods' in impact) and not impact['application_periods']\
-                        and ('application_period_patterns' not in impact
-                             or not impact['application_period_patterns']):
-                    return marshal(
-                        {'error': {'message': "application_periods should not be empty"}},
-                        fields.error_fields
-                    ), 400
-                elif ('application_period_patterns' in impact) and not impact['application_period_patterns']\
-                        and 'application_periods' not in impact:
-                    return marshal(
-                        {'error': {'message': "application_period_patterns should not be empty"}},
-                        fields.error_fields
-                    ), 400
-            return func(*args, **kwargs)
 
+            # in each impact
+            required_arrays_for_impact = ['objects', 'application_periods', 'application_period_patterns']
+            for impact in impacts:
+                for required_array in required_arrays_for_impact:  # type: str
+                    if (required_array in impact) and not impact[required_array]:
+                        return marshal(
+                            {'error': {'message': "{} should not be empty".format(required_array)}},
+                            fields.error_fields
+                        ), 400
+
+            return func(*args, **kwargs)
         return wrapper

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -158,7 +158,6 @@ class validate_client_token(object):
             return func(*args, **kwargs)
         return wrapper
 
-# To override the default validator message "[] is too short"
 class validate_send_notifications_and_notification_date(object):
     def __call__(self, func):
         @wraps(func)
@@ -179,6 +178,7 @@ class validate_send_notifications_and_notification_date(object):
             return func(*args, **kwargs)
         return wrapper
 
+# To override the default validator message "[] is too short"
 class validate_required_arrays(object):
     def __call__(self, func):
         @wraps(func)

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -181,7 +181,7 @@ class validate_send_notifications_and_notification_date(object):
 
 
 # To override the default validator message "[] is too short"
-class validate_required_arrays(object):
+class validate_required_list_of_impact(object):
     def __call__(self, func):
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -181,7 +181,7 @@ class validate_send_notifications_and_notification_date(object):
 
 
 # To override the default validator message "[] is too short"
-class validate_required_list_of_impact(object):
+class validate_impact_lists(object):
     def __call__(self, func):
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -187,27 +187,34 @@ class validate_impact_lists(object):
         def wrapper(*args, **kwargs):
             json = request.get_json(silent=True)
             impacts = []
-
-            # in disruption
-            if json and 'impacts' in json:  # json is disruption
+            if json and 'impacts' in json:
                 impacts = json['impacts']
                 if not impacts:
                     return marshal(
                         {'error': {'message': "impacts should not be empty"}},
                         fields.error_fields
                     ), 400
-            elif json and 'severity' in json:  # json is impact
+            elif json and 'severity' in json:
                 impacts = [json]
-
-            # in each impact
-            required_arrays_for_impact = ['objects', 'application_periods']
             for impact in impacts:
-                for required_array in required_arrays_for_impact:  # type: str
-                    if (required_array in impact) and not impact[required_array]:
-                        return marshal(
-                            {'error': {'message': "{} should not be empty".format(required_array)}},
-                            fields.error_fields
-                        ), 400
-
+                if ('objects' in impact) and not impact['objects']:
+                    return marshal(
+                        {'error': {'message': "objects should not be empty"}},
+                        fields.error_fields
+                    ), 400
+                elif ('application_periods' in impact) and not impact['application_periods']\
+                        and ('application_period_patterns' not in impact
+                             or not impact['application_period_patterns']):
+                    return marshal(
+                        {'error': {'message': "application_periods should not be empty"}},
+                        fields.error_fields
+                    ), 400
+                elif ('application_period_patterns' in impact) and not impact['application_period_patterns']\
+                        and 'application_periods' not in impact:
+                    return marshal(
+                        {'error': {'message': "application_period_patterns should not be empty"}},
+                        fields.error_fields
+                    ), 400
             return func(*args, **kwargs)
+
         return wrapper

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -29,7 +29,7 @@
 
 from functools import wraps
 from chaos.navitia import Navitia
-from utils import get_client_code, get_contributor_code, get_token,\
+from utils import get_client_code, get_contributor_code, get_token, \
     get_coverage, get_clients_tokens, client_token_is_allowed
 from chaos import exceptions, models, utils, fields
 from flask_restful import marshal
@@ -187,18 +187,19 @@ class validate_required_arrays(object):
         def wrapper(*args, **kwargs):
             json = request.get_json(silent=True)
             impacts = []
-            # in a disruption
-            if json and 'impacts' in json:
+
+            # in disruption
+            if json and 'impacts' in json:  # json is disruption
                 impacts = json['impacts']
                 if not impacts:
                     return marshal(
                         {'error': {'message': "impacts should not be empty"}},
                         fields.error_fields
                     ), 400
-            elif json and 'severity' in json:
+            elif json and 'severity' in json:  # json is impact
                 impacts = [json]
 
-            # in an impact
+            # in each impact
             required_arrays_for_impact = ['objects', 'application_periods']
             for impact in impacts:
                 for required_array in required_arrays_for_impact:  # type: str

--- a/tests/features/create-disruption.feature
+++ b/tests/features/create-disruption.feature
@@ -488,7 +488,7 @@ Feature: Create disruption
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "[] is too short"
+        And the field "error.message" should be "impacts should not be empty"
 
 
     Scenario: Error when creating disruption with impact without objects

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -709,3 +709,75 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "u'' does not match '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$'"
+
+    Scenario: Add an impact in a disruption without objects
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "objects should not be empty"
+
+    Scenario: Add an impact in a disruption without application_periods
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_periods": []}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "application_periods should not be empty"

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -781,3 +781,40 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "application_periods should not be empty"
+
+
+    Scenario: Add an impact in a disruption without application_period_patterns
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_period_patterns": []}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "application_period_patterns should not be empty"

--- a/tests/features/update-disruption-with-impacts.feature
+++ b/tests/features/update-disruption-with-impacts.feature
@@ -322,7 +322,7 @@ Feature: Update Disruption and impacts
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "[] is too short"
+        And the field "error.message" should be "impacts should not be empty"
 
     Scenario: Update disruption with impact without objects
 


### PR DESCRIPTION
# Description

This PR add validator to override the default validator message "[] is too short"
## Issue (optional)

Issue link: bot-749

## How to test

Here are the following steps to test this pull request:

- POST / PUT disruption and POST / PUT impact with "impacts":[]
- POST / PUT disruption and POST / PUT impact with "objects":[]
- POST / PUT disruption and POST / PUT impact with "application_periods":[]
