### PR TITLE
Add management of empty array error in json validator

### DIFF
--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -279,14 +279,7 @@ class Disruptions(flask_restful.Resource):
         return self.get_error_response_and_log('PUT', exception, status_code)
 
     def get_error_response_and_log(self, method, exception, status_code):
-        if (isinstance(exception, ValidationError) and exception.validator ==
-                'minItems' and exception.validator_value == 1):
-            exception.schema_path.rotate(1)
-            response_content = marshal({'error': {'message': '{} should not be empty'.format(
-                exception.schema_path.pop())}}, error_fields)
-        else:
-            response_content = marshal(
-                {'error': {'message': '{}'.format(exception.message)}}, error_fields)
+        response_content = marshal({'error': {'message': utils.parse_error(exception)}}, error_fields)
         logging.getLogger(__name__).debug(
             "\nError REQUEST %s disruption: [X-Customer-Id:%s;X-Coverage:%s;X-Contributors:%s;Authorization:%s] with payload \n%s" +
             "\ngot RESPONSE with status %d:\n%s",

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -279,7 +279,14 @@ class Disruptions(flask_restful.Resource):
         return self.get_error_response_and_log('PUT', exception, status_code)
 
     def get_error_response_and_log(self, method, exception, status_code):
-        response_content = marshal({'error': {'message': '{}'.format(exception.message)}}, error_fields)
+        if (isinstance(exception, ValidationError) and exception.validator ==
+                'minItems' and exception.validator_value == 1):
+            exception.schema_path.rotate(1)
+            response_content = marshal({'error': {'message': '{} should not be empty'.format(
+                exception.schema_path.pop())}}, error_fields)
+        else:
+            response_content = marshal(
+                {'error': {'message': '{}'.format(exception.message)}}, error_fields)
         logging.getLogger(__name__).debug(
             "\nError REQUEST %s disruption: [X-Customer-Id:%s;X-Coverage:%s;X-Contributors:%s;Authorization:%s] with payload \n%s" +
             "\ngot RESPONSE with status %d:\n%s",

--- a/chaos/utils.py
+++ b/chaos/utils.py
@@ -338,7 +338,12 @@ def group_impacts_by_pt_object(impacts, object_type, uris, get_pt_object):
 def parse_error(error):
     to_return = None
     try:
-        to_return = error.message
+        if (isinstance(error, ValidationError) and error.validator ==
+                'minItems' and error.validator_value == 1):
+            error.schema_path.rotate(1)
+            to_return = '{} should not be empty'.format(error.schema_path.pop())
+        else:
+            to_return = error.message
     except AttributeError:
         to_return = str(error).replace("\n", " ")
     return to_return.decode('utf-8')

--- a/tests/features/create-cause.feature
+++ b/tests/features/create-cause.feature
@@ -29,7 +29,7 @@ Feature: Create cause
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "[] is too short"
+        And the field "error.message" should be "wordings should not be empty"
 
     Scenario: creation of cause
         Given I have the following clients in my database:

--- a/tests/features/create-disruption-with-impacts.feature
+++ b/tests/features/create-disruption-with-impacts.feature
@@ -150,6 +150,17 @@ Feature: Create Disruption and impacts
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "'value' is a required property"
 
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions" with:
+        """
+        {"reference": "foo", "contributor": "contrib1", "cause":{"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"}, "publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"}, "impacts": [{"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"},{"begin": "2014-04-29T16:52:00Z","end": "2014-05-22T02:15:00Z"}], "objects": [{"id":"line:JDR:M5", "type":"line_section","line_section": {"line":{"id":"line:JDR:M5","type":"line"}, "start_point":{"id":"stop_area:JDR:SA:BASTI", "type":"stop_area"}, "end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "sens":2, "routes":[{"type":"route", "id":"route:JDR:M14"}, {"type":"route", "id":"route:JDR:M1"}], "metas":[] }}]}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "metas should not be empty"
+
     Scenario: creation of disruption with one impact and send_notifications not exist
 
         Given I have the following clients in my database:

--- a/tests/features/create-disruption.feature
+++ b/tests/features/create-disruption.feature
@@ -488,7 +488,7 @@ Feature: Create disruption
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "[] is too short"
+        And the field "error.message" should be "impacts should not be empty"
 
 
     Scenario: Error when creating disruption with impact without objects

--- a/tests/features/create-severity.feature
+++ b/tests/features/create-severity.feature
@@ -184,3 +184,12 @@ Feature: Create severity
         And the field "severity.color" should be "#123456"
         And the field "severity.priority" should be "9"
         And the field "severity.effect" should be "stop_moved"
+
+    Scenario: We cannot create a severity with empty wording
+        When I post to "/severities" with:
+        """
+        {"wordings": [], "color": "#123456", "priority": 9, "effect": "stop_moved"}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "wordings should not be empty"

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -709,3 +709,112 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "u'' does not match '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$'"
+
+        Scenario: Add an impact in a disruption without objects
+
+	        Given I have the following clients in my database:
+	            | client_code   | created_at          | updated_at          | id                                   |
+	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following contributors in my database:
+	            | contributor_code   | created_at          | updated_at          | id                                   |
+	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following causes in my database:
+	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following disruptions in my database:
+	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following severities in my database:
+	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+	        I fill in header "X-Customer-Id" with "5"
+	        I fill in header "X-Contributors" with "contrib1"
+	        I fill in header "X-Coverage" with "jdr"
+	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+	        """
+	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+	        """
+	        Then the status code should be "400"
+	        And the header "Content-Type" should be "application/json"
+	        And the field "error.message" should be "objects should not be empty"
+
+	    Scenario: Add an impact in a disruption without application_periods
+
+	        Given I have the following clients in my database:
+	            | client_code   | created_at          | updated_at          | id                                   |
+	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following contributors in my database:
+	            | contributor_code   | created_at          | updated_at          | id                                   |
+	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following causes in my database:
+	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following disruptions in my database:
+	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following severities in my database:
+	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+	        I fill in header "X-Customer-Id" with "5"
+	        I fill in header "X-Contributors" with "contrib1"
+	        I fill in header "X-Coverage" with "jdr"
+	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+	        """
+	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_periods": []}
+	        """
+	        Then the status code should be "400"
+	        And the header "Content-Type" should be "application/json"
+	        And the field "error.message" should be "application_periods should not be empty"
+
+
+	    Scenario: Add an impact in a disruption without application_period_patterns
+
+	        Given I have the following clients in my database:
+	            | client_code   | created_at          | updated_at          | id                                   |
+	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following contributors in my database:
+	            | contributor_code   | created_at          | updated_at          | id                                   |
+	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following causes in my database:
+	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following disruptions in my database:
+	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+	        Given I have the following severities in my database:
+	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+	        I fill in header "X-Customer-Id" with "5"
+	        I fill in header "X-Contributors" with "contrib1"
+	        I fill in header "X-Coverage" with "jdr"
+	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+	        """
+	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_period_patterns": []}
+	        """
+	        Then the status code should be "400"
+	        And the header "Content-Type" should be "application/json"
+	        And the field "error.message" should be "application_period_patterns should not be empty"

--- a/tests/features/impacts-with-application_period_patterns.feature
+++ b/tests/features/impacts-with-application_period_patterns.feature
@@ -40,6 +40,42 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.application_periods" should contain all of "{"begin": "2015-02-02T06:45:00Z", "end": "2015-02-02T08:30:00Z"}"
         And the field "impact.application_periods" should contain all of "{"begin": "2015-02-06T06:45:00Z", "end": "2015-02-06T08:30:00Z"}"
 
+    Scenario: Add an impact in a disruption with a application_period pattern having time_slot empty
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "application_period_patterns":[{"start_date":"2015-02-01","end_date":"2015-02-06","weekly_pattern":"1111100","time_zone":"Europe/Paris","time_slots":[]}],"objects": [{"id": "network:JDR:1","type": "network"}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "time_slots should not be empty"
+
+
     #One of application_period pattern or application_periods is required
     Scenario: Add an impact in a disruption with a application_period pattern having one time_slot and application_periods fails
 
@@ -201,6 +237,55 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.application_periods" should contain all of "{"begin": "2015-02-02T06:45:00Z", "end": "2015-02-02T08:30:00Z"}"
         And the field "impact.application_periods" should contain all of "{"begin": "2015-02-03T06:45:00Z", "end": "2015-02-03T08:30:00Z"}"
         And the field "impact.application_periods" should contain all of "{"begin": "2015-02-01T09:45:00Z", "end": "2015-02-01T15:30:00Z"}"
+
+    Scenario: update an impact in a disruption with a application_period pattern having time_slot empty
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | a750994c-01fe-11e4-b4fb-080027079ff3 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following pattern in my database:
+            | created_at          | updated_at          | id                                   | impact_id                              | weekly_pattern|start_date         |end_date           |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 7ffab200-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b6   |1111100        |2014-04-06T22:52:12|2014-04-10T22:52:12|
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 7ffab201-3d47-4eea-aa2c-22f8680230b6 | 7ffab232-3d47-4eea-aa2c-22f8680230b6   |0000011        |2014-04-06T22:52:12|2014-04-10T22:52:12|
+
+        Given I have the following timeslot in my database:
+            | created_at          | updated_at          | id                                   | pattern_id                          | begin|end  |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 7ffab200-3d47-4eea-aa2c-22f8680230b6 | 7ffab200-3d47-4eea-aa2c-22f8680230b6|07:10 |10:10|
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 7ffab201-3d47-4eea-aa2c-22f8680230b6 | 7ffab201-3d47-4eea-aa2c-22f8680230b6|07:10 |10:10|
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I put to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b6" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "application_period_patterns":[{"start_date":"2015-02-01","end_date":"2015-02-06","weekly_pattern":"1111100","time_zone":"Europe/Paris","time_slots":[]}],"objects": [{"id": "network:JDR:1","type": "network"}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "time_slots should not be empty"
+
 
     Scenario: Update an impact in a disruption having a pattern with two application_period
 

--- a/tests/features/impacts-with-pt-objects.feature
+++ b/tests/features/impacts-with-pt-objects.feature
@@ -1091,3 +1091,95 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "'value' is a required property"
+
+        Scenario: Put impact with line_section invalid wording in json : 2 wordings in database
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type         | uri                                              | created_at          | id                                         |
+            | stop_area    | stop_area:JDR:SA:BASTI                           | 2014-04-04T23:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | stop_area    | stop_area:JDR:SA:CHVIN                           | 2014-04-04T23:52:12 | 2ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line_section | line:JDR:M1:7ffab234-3d49-4eea-aa2c-22f8680230b6 | 2014-04-04T23:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line         | line:JDR:M1                                      | 2014-04-06T22:52:12 | 4ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M14                                    | 2014-04-06T22:52:12 | 5ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | route        | route:JDR:M1_R                                   | 2014-04-06T22:52:12 | 6ffab200-3d48-4eea-aa2c-22f8680230b6       |
+            | network      | network:TAD:CanalTP                              | 2014-04-04T23:52:12 | 9ffab232-3d48-4eea-aa2c-22f8680230b6       |
+
+
+
+        Given I have the following line_section in my database:
+            | id                                    | line_object_id                        | created_at            | updated_at          | start_object_id                      |end_object_id|sens|object_id|
+            | 7ffab234-3d49-4eea-aa2c-22f8680230b6  | 4ffab232-3d48-4eea-aa2c-22f8680230b6  | 2014-04-04T23:52:12   | 2014-04-04T23:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b6 |2ffab232-3d48-4eea-aa2c-22f8680230b6|0|3ffab232-3d48-4eea-aa2c-22f8680230b6|
+
+        Given I have the following wording in my database:
+            | key       | value     | created_at          | updated_at          | id                                   |
+            |  key1     | 1234      | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
+            |  key2     | 235       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the relation associate_wording_line_section in my database:
+            | wording_id                                | line_section_id                       |
+            |  7ffab230-3d48-4eea-aa2c-22f8680230b6     | 7ffab234-3d49-4eea-aa2c-22f8680230b6  |
+            |  7ffab232-3d48-4eea-aa2c-22f8680230b6     | 7ffab234-3d49-4eea-aa2c-22f8680230b6  |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 9ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+
+        Given I have the relation associate_line_section_route_object in my database:
+            | route_object_id                               | line_section_id                      |
+            | 5ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+            | 6ffab200-3d48-4eea-aa2c-22f8680230b6          | 7ffab234-3d49-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-01-20 16:52:00                  |2014-01-30 16:52:00 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I put to "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b6" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id":"line:JDR:M5", "type":"line_section","line_section": {"line":{"id":"line:JDR:M5","type":"line"}, "start_point":{"id":"stop_area:JDR:SA:BASTI", "type":"stop_area"}, "end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "sens":2, "routes":[{"type":"route", "id":"route:JDR:M14"}, {"type":"route", "id":"route:JDR:M1"}], "metas":[{"key":"direction"}] }}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "'value' is a required property"
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I put to "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts/7ffab232-3d47-4eea-aa2c-22f8680230b6" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id":"line:JDR:M5", "type":"line_section","line_section": {"line":{"id":"line:JDR:M5","type":"line"}, "start_point":{"id":"stop_area:JDR:SA:BASTI", "type":"stop_area"}, "end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "sens":2, "routes":[{"type":"route", "id":"route:JDR:M14"}, {"type":"route", "id":"route:JDR:M1"}], "metas":[] }}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "metas should not be empty"

--- a/tests/features/list-post-disruptions-search.feature
+++ b/tests/features/list-post-disruptions-search.feature
@@ -62,6 +62,42 @@ Feature: list disruptions with ptObjects filter
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
 
+    Scenario: Filter on network with empty publication_status
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": [], "ptObjectFilter": {"networks": ["network:JDR:1"]}}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "publication_status should not be empty"
+
+    Scenario: Filter on network with empty status
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "status": [], "ptObjectFilter": {"networks": ["network:JDR:1"]}}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "status should not be empty"
+
     Scenario: Filter on network
 
         Given I have the following contributors in my database:

--- a/tests/features/update-cause.feature
+++ b/tests/features/update-cause.feature
@@ -88,6 +88,14 @@ Feature: update cause
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
 
+        When I put to "/causes/7ffab230-3d48-4eea-aa2c-22f8680230b6" with:
+        """
+        {"wordings":[]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "wordings should not be empty"
+
     Scenario: I can update the wording of a cause
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |

--- a/tests/features/update-disruption-with-impacts.feature
+++ b/tests/features/update-disruption-with-impacts.feature
@@ -322,7 +322,7 @@ Feature: Update Disruption and impacts
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
-        And the field "error.message" should be "[] is too short"
+        And the field "error.message" should be "impacts should not be empty"
 
     Scenario: Update disruption with impact without objects
 

--- a/tests/features/update-severity.feature
+++ b/tests/features/update-severity.feature
@@ -76,7 +76,7 @@ Feature: update severity
         """
         Then the status code should be "404"
 
-    Scenario: a severity must have a wording
+    Scenario: a severity must have a wording and it should not be empty
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
@@ -91,6 +91,15 @@ Feature: update severity
         """
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
+
+        I fill in header "X-Customer-Id" with "5"
+        When I put to "/severities/7ffab230-3d48-4eea-aa2c-22f8680230b6" with:
+        """
+        {"wordings": [], "color": "foo"}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "wordings should not be empty"
 
     Scenario: I can update the wording of a severity
         Given I have the following clients in my database:

--- a/tests/json_validator_error_test.py
+++ b/tests/json_validator_error_test.py
@@ -19,7 +19,7 @@ def test_wording_is_empty_in_severity():
         validate({'wordings': []}, severity_input_format)
         assert False
     except ValidationError, e:
-        eq_(parse_error(e), "[] is too short", True)
+        eq_(parse_error(e), "wordings should not be empty", True)
 
 
 def test_wording_is_value_not_in__wordings_severity():
@@ -83,7 +83,7 @@ def test_channel_types_name_is_required_in_channel():
         validate({"name": "sms", "max_size": 500, "content_type": "text/type", "types": []}, channel_input_format)
         assert False
     except ValidationError, e:
-        eq_(parse_error(e), "[] is too short", True)
+        eq_(parse_error(e), "types should not be empty", True)
 
 
 def test_name_required_in_channel_types():
@@ -91,7 +91,7 @@ def test_name_required_in_channel_types():
         validate({"name": "sms", "max_size": 500, "content_type": "text/type", "types": []}, channel_input_format)
         assert False
     except ValidationError, e:
-        eq_(parse_error(e), "[] is too short", True)
+        eq_(parse_error(e), "types should not be empty", True)
 
 
 def test_reference_is_required_in_disruption():
@@ -214,7 +214,7 @@ def test_min_1_impact_is_required_in_disruption():
         validate({"reference": "foo","contributor": "contrib1","publication_period": {"begin": "2014-06-24T10:35:00Z","end": "2018-06-24T10:35:00Z"},"localization": [{"id": "stop_area:JDR:SA:CHVIN","type": "stop_area"}],"cause": {"id": "7ffab230-3d48-4eea-aa2c-22f8680230b6"},"impacts": []}, disruptions_input_format)
         assert True
     except ValidationError, e:
-        eq_(parse_error(e), "[] is too short", True)
+        eq_(parse_error(e), "impacts should not be empty", True)
 
 def test_impact_format_is_checked_in_disruption():
     try:


### PR DESCRIPTION
# Description

This PR change the error message to override the default validator message "[] is too short"

## Issue

Issue link: bot-749

## How to test

Here are the following steps to test this pull request:

- POST / PUT disruption and POST / PUT impact with "impacts":[]
- POST / PUT disruption and POST / PUT impact with "objects":[]
- POST / PUT disruption and POST / PUT impact with "application_periods":[]
... (you can use also all array that have this validation : minItems = 1 -> see chaos\formats.py)
