### PR TITLE
Limit items_per_page parameter

### DIFF
--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -184,8 +184,10 @@ class validate_pagination(object):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             request_args = self.parsers[self.parsers.keys()[0]].parse_args()
-            if request_args['start_page'] == 0:
+            if request_args['start_page'] <= 0:
                 abort(400, message="page_index argument value is not valid")
+            if request_args['items_per_page'] < 0:
+                abort(400, message="items_per_page argument value is not valid")
             if request_args['items_per_page'] > 1000:
                 abort(400, message="items_per_page argument value can't be superior than 1000")
             return func(self, *args, **kwargs)

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -32,6 +32,7 @@ from chaos.navitia import Navitia
 from utils import get_client_code, get_contributor_code, get_token, get_coverage, get_clients_tokens, client_token_is_allowed
 from chaos import exceptions, models, utils, fields
 from flask_restful import marshal
+from flask.ext.restful import abort
 from flask import request, current_app
 from formats import id_format
 from os import path
@@ -176,4 +177,18 @@ class validate_send_notifications_and_notification_date(object):
                         fields.error_fields
                     ), 400
             return func(*args, **kwargs)
+        return wrapper
+
+class validate_pagination(object):
+    def __call__(self, func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            request_args = self.parsers[self.parsers.keys()[0]].parse_args()
+            if request_args['start_page'] == 0:
+                abort(400, message="page_index argument value is not valid")
+            if request_args['items_per_page'] == 0:
+                abort(400, message="items_per_page argument value is not valid")
+            if request_args['items_per_page'] > 1000:
+                abort(400, message="items_per_page argument value can't be superior than 1000")
+            return func(self, *args, **kwargs)
         return wrapper

--- a/chaos/validate_params.py
+++ b/chaos/validate_params.py
@@ -186,8 +186,6 @@ class validate_pagination(object):
             request_args = self.parsers[self.parsers.keys()[0]].parse_args()
             if request_args['start_page'] == 0:
                 abort(400, message="page_index argument value is not valid")
-            if request_args['items_per_page'] == 0:
-                abort(400, message="items_per_page argument value is not valid")
             if request_args['items_per_page'] > 1000:
                 abort(400, message="items_per_page argument value can't be superior than 1000")
             return func(self, *args, **kwargs)

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1651,7 +1651,7 @@
       required: false
       type: integer
       default: 20
-      minimum: 1
+      minimum: 0
       maximum: 1000
     publication_status:
       in: query
@@ -2165,7 +2165,7 @@
           description: Number of items per page
           type: integer
           default: 20
-          minimum: 1
+          minimum: 0
           maximum: 1000
           example: 20
         application_status:
@@ -2556,7 +2556,7 @@
           description: Number of items per page
           type: integer
           default: 20
-          minimum: 1
+          minimum: 0
           maximum: 1000
           example: 20
         application_status:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1651,6 +1651,8 @@
       required: false
       type: integer
       default: 20
+      minimum: 1
+      maximum: 1000
     publication_status:
       in: query
       name: publication_status
@@ -2163,6 +2165,9 @@
           description: Number of items per page
           type: integer
           default: 20
+          minimum: 1
+          maximum: 1000
+          example: 20
         application_status:
           description: Filter by application_status (on impact)
           default:
@@ -2551,6 +2556,9 @@
           description: Number of items per page
           type: integer
           default: 20
+          minimum: 1
+          maximum: 1000
+          example: 20
         application_status:
           description: Filter by application_status (on impact)
           default:

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -169,7 +169,7 @@ Feature: list disruptions with pager
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "page_index argument value is not valid"
 
-    Scenario: Use pager to display disruptions with parameters (items_per_page=0)
+    Scenario: Use pager to display disruptions with parameters (items_per_page not valid)
 
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
@@ -195,6 +195,11 @@ Feature: list disruptions with pager
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "items_per_page argument value is not valid"
+
+        When I get "/disruptions?start_page=1&items_per_page=1001"
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value can't be superior than 1000"
 
     Scenario: Use pager to order disruptions with identical end_publication_date
 

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -191,6 +191,11 @@ Feature: list disruptions with pager
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
 
+        When I get "/disruptions?start_page=1&items_per_page=-1"
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
+
         When I get "/disruptions?start_page=1&items_per_page=1001"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"

--- a/tests/features/list-disruptions-with-pager.feature
+++ b/tests/features/list-disruptions-with-pager.feature
@@ -191,11 +191,6 @@ Feature: list disruptions with pager
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
 
-        When I get "/disruptions?start_page=1&items_per_page=0"
-        Then the status code should be "400"
-        And the header "Content-Type" should be "application/json"
-        And the field "message" should be "items_per_page argument value is not valid"
-
         When I get "/disruptions?start_page=1&items_per_page=1001"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
@@ -289,7 +284,7 @@ Feature: list disruptions with pager
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruption.impacts.impacts" should have a size of 6
-        
+
     Scenario: Retrieve just published impacts
 
         Given I have the following contributors in my database:

--- a/tests/features/list-impacts-with-pager.feature
+++ b/tests/features/list-impacts-with-pager.feature
@@ -328,11 +328,6 @@ Feature: list impacts with pager
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eec-aa2c-22f8680230b4 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
-        When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts?start_page=1&items_per_page=0"
-        Then the status code should be "400"
-        And the header "Content-Type" should be "application/json"
-        And the field "message" should be "items_per_page argument value is not valid"
-
         When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts?start_page=1&items_per_page=1001"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"

--- a/tests/features/list-impacts-with-pager.feature
+++ b/tests/features/list-impacts-with-pager.feature
@@ -328,6 +328,11 @@ Feature: list impacts with pager
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eea-aa2c-22f8680230b3 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab234-3d49-4eec-aa2c-22f8680230b4 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
+        When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts?start_page=1&items_per_page=-1"
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
+
         When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts?start_page=1&items_per_page=1001"
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"

--- a/tests/features/list-impacts-with-pager.feature
+++ b/tests/features/list-impacts-with-pager.feature
@@ -302,7 +302,7 @@ Feature: list impacts with pager
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "page_index argument value is not valid"
 
-    Scenario: Impacts with items_per_page=0
+    Scenario: Impacts with items_per_page not valid
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
@@ -332,3 +332,8 @@ Feature: list impacts with pager
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "items_per_page argument value is not valid"
+
+        When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6/impacts?start_page=1&items_per_page=1001"
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value can't be superior than 1000"

--- a/tests/features/list-post-disruptions-search.feature
+++ b/tests/features/list-post-disruptions-search.feature
@@ -485,12 +485,28 @@ Feature: list disruptions with ptObjects filter
 
         When I post to "/disruptions/_search" with:
         """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": -1, "items_per_page": 3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "page_index argument value is not valid"
+
+        When I post to "/disruptions/_search" with:
+        """
         {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
         """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "disruptions" should have a size of 0
         And the field "meta" should exist
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": -3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
 
         When I post to "/disruptions/_search" with:
         """

--- a/tests/features/list-post-disruptions-search.feature
+++ b/tests/features/list-post-disruptions-search.feature
@@ -487,9 +487,10 @@ Feature: list disruptions with ptObjects filter
         """
         {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
         """
-        Then the status code should be "400"
+        Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
-        And the field "message" should be "items_per_page argument value is not valid"
+        And the field "disruptions" should have a size of 0
+        And the field "meta" should exist
 
         When I post to "/disruptions/_search" with:
         """

--- a/tests/features/list-post-disruptions-search.feature
+++ b/tests/features/list-post-disruptions-search.feature
@@ -475,6 +475,30 @@ Feature: list disruptions with ptObjects filter
         And the field "meta.pagination.start_page" should be 1
         And the field "meta.pagination.total_result" should be 4
 
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 0, "items_per_page": 3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "page_index argument value is not valid"
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
+
+        When I post to "/disruptions/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "publication_status": ["ongoing"], "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 1001}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value can't be superior than 1000"
+
     Scenario: Test if about body when ptObjectFilter is not added
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |

--- a/tests/features/post-impacts-search.feature
+++ b/tests/features/post-impacts-search.feature
@@ -439,6 +439,31 @@ Feature: list disruptions with ptObjects filter
         And the field "meta.pagination.start_page" should be 1
         And the field "meta.pagination.total_result" should be 4
 
+        When I post to "/impacts/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 0, "items_per_page": 3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "page_index argument value is not valid"
+
+        When I post to "/impacts/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
+
+        When I post to "/impacts/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 1001}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value can't be superior than 1000"
+
+
     Scenario: Test if about body when ptObjectFilter is not added
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |

--- a/tests/features/post-impacts-search.feature
+++ b/tests/features/post-impacts-search.feature
@@ -449,12 +449,28 @@ Feature: list disruptions with ptObjects filter
 
         When I post to "/impacts/_search" with:
         """
+        {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": -1, "items_per_page": 3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "page_index argument value is not valid"
+
+        When I post to "/impacts/_search" with:
+        """
         {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
         """
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "impacts" should have a size of 0
         And the field "meta" should exist
+
+        When I post to "/impacts/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": -3}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "message" should be "items_per_page argument value is not valid"
 
         When I post to "/impacts/_search" with:
         """

--- a/tests/features/post-impacts-search.feature
+++ b/tests/features/post-impacts-search.feature
@@ -451,9 +451,10 @@ Feature: list disruptions with ptObjects filter
         """
         {"current_time": "2014-04-15T14:00:00Z", "ptObjectFilter": {"networks": ["network:JDR:1"]}, "start_page": 1, "items_per_page": 0}
         """
-        Then the status code should be "400"
+        Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
-        And the field "message" should be "items_per_page argument value is not valid"
+        And the field "impacts" should have a size of 0
+        And the field "meta" should exist
 
         When I post to "/impacts/_search" with:
         """


### PR DESCRIPTION
# Description

This PR limit items_per_page parameter in order to limit the potential excessive usage of the API

## Issue

Issue link: BOT-839

## How to test

Here are the following steps to test this pull request:

- Get to API disruptions with parameter items_per_page > 1000
- Post to API disruptions/_search with parameter items_per_page > 1000
- Post to API impacts/_search with parameter items_per_page > 1000
- You should the the error