### PR TITLE
Update documentation with author attribute of disruption

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1893,6 +1893,9 @@
         contributor:
           type: string
           description: Contributor code
+        author:
+          type: string
+          description: ID of disruption creator or editor
         created_at:
           type: string
           pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -3077,6 +3077,8 @@
         contributor:
           type: string
           description: Contributor code
+        author:
+          $ref: "#/definitions/author"
         created_at:
           type: string
           pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -1894,8 +1894,7 @@
           type: string
           description: Contributor code
         author:
-          type: string
-          description: ID of disruption creator or editor
+          $ref: "#/definitions/author"
         created_at:
           type: string
           pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
@@ -2015,6 +2014,8 @@
         contributor:
           type: string
           description: Contributor code (same as header X-Contributors)
+        author:
+          $ref: "#/definitions/author"
         status:
           type: string
           enum:
@@ -3180,3 +3181,6 @@
         version:
           type: integer
           description: Number of how many time this disruption has been changed
+    author:
+      type: string
+      description: ID of disruption creator or editor


### PR DESCRIPTION
# Description

This PR updates swagger documentation of author attribute on disruption

## Issue (optional)

Issue link: BOT-1544

## Pull Request type (optional)

This is a new feature