### PR TITLE
Add line_section validation entry

### DIFF
--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -41,7 +41,7 @@ def fill_and_get_pt_object(navitia, all_objects, json, add_to_db=True):
 
     if json["id"] in all_objects:
         return all_objects[json["id"]]
-    
+
     if not navitia.get_pt_object(json['id'], json['type']):
         raise exceptions.ObjectUnknown()
 
@@ -139,6 +139,8 @@ def fill_and_add_line_section(navitia, impact_id, all_objects, pt_object_json):
     mapper.fill_from_json(ptobject, pt_object_json, mapper.object_mapping)
 
     # Here we treat all the objects in line_section like line, start_point, end_point
+    if 'line_section' not in pt_object_json:
+        raise exceptions.InvalidJson('Object of type line_section must have a line_section entry')
     line_section_json = pt_object_json['line_section']
 
     ptobject.uri = ":".join((line_section_json['line']['id'], ptobject.id))

--- a/tests/features/impacts-with-pt-objects.feature
+++ b/tests/features/impacts-with-pt-objects.feature
@@ -386,6 +386,42 @@ Feature: Manipulate impacts in a Disruption
         And the field "impact.objects.0.line_section.end_point.id" should be "stop_area:JDR:SA:BERAU"
         And the field "impact.objects.0.line_section.sens" should be 1
 
+    Scenario: Add an impact in a disruption with one object line_section invalid
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id":"line:JDR:M1", "type":"line_section", "line":{"id":"line:JDR:M1","type":"line"}, "start_point":{"id":"stop_area:JDR:SA:PTVIN", "type":"stop_area"}, "end_point":{"id":"stop_area:JDR:SA:BERAU", "type":"stop_area"}}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"},{"begin": "2014-04-29T16:52:00Z","end": "2014-05-22T02:15:00Z"}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should exist
+        And the field "error.message" should be "Object of type line_section must have a line_section entry"
+
     Scenario: Add an impact in a disruption with 2 objects line_section valid
 
         Given I have the following clients in my database:
@@ -1218,7 +1254,7 @@ Feature: Manipulate impacts in a Disruption
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "metas should not be empty"
-        
+
     Scenario: Add an impact in a disruption with token invalid (no token file filter)
 
         Given I have the following clients in my database:

--- a/tests/json_validator_error_test.py
+++ b/tests/json_validator_error_test.py
@@ -110,7 +110,7 @@ def test_cause_is_required_in_disruption():
         eq_(parse_error(e), "'cause' is a required property", True)
 
 
-def test_severity_is_required_in_impcat():
+def test_severity_is_required_in_impact():
     try:
         validate({"application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-05-22T02:15:00Z"},{"begin": "2014-04-29T16:52:00Z","end": "2014-05-22T02:15:00Z"}]}, impact_input_format)
         assert False
@@ -118,7 +118,7 @@ def test_severity_is_required_in_impcat():
         eq_(parse_error(e), "'severity' is a required property", True)
 
 
-def test_begin_date_is_required_in_impcat():
+def test_begin_date_is_required_in_impact():
     try:
         validate({"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "application_periods": [{"end": "2014-05-22T02:15:00Z"}, {"begin": None,"end": "2014-05-22T02:15:00Z"}],"objects": [{"id": "network:JDR:1", "type": "network"}]}, impact_input_format)
         assert False
@@ -126,7 +126,7 @@ def test_begin_date_is_required_in_impcat():
         eq_(parse_error(e), "'begin' is a required property", True)
 
 
-def test_id_object_is_required_in_impcat():
+def test_id_object_is_required_in_impact():
     try:
         validate({"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "network:JDR:2","type": "network"}, {"type": "stop_area"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}, impact_input_format)
         assert False
@@ -134,18 +134,18 @@ def test_id_object_is_required_in_impcat():
         eq_(parse_error(e), "'id' is a required property", True)
 
 
-def test_type_object_is_required_in_impcat():
+def test_type_object_is_required_in_impact():
     try:
         validate({"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "network:JDR:2","type": "network"}, {"id": "network:JDR:1"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}, impact_input_format)
         assert False
     except ValidationError, e:
         eq_(parse_error(e), "'type' is a required property", True)
 
-def test_pt_object_stop_point_in_impcat():
+def test_pt_object_stop_point_in_impact():
     validate({"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "stop_point:JDR:2", "type": "stop_point"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}, impact_input_format)
 
 
-def test_not_pt_object_in_impcat():
+def test_not_pt_object_in_impact():
     try:
         validate({"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route_point:JDR:2", "type": "route_point"}], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}, impact_input_format)
         assert False


### PR DESCRIPTION
# Description

This PR fix the debugger error shown if you try to add an impact of type line_section without line_section entry

## Issue

Issue link: BOT-1666

## How to test

Here are the following steps to test this pull request:

- try to create a disruption with an impact who have an object of type line_section and do not add the line_section part
- you should see a return of the API (validation error)

NB : PR https://github.com/CanalTP/Chaos/pull/413 has already an example of a correct line_section impact creation