### PR TITLE
Rename impact_line_section_object

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2879,7 +2879,7 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
-              - $ref: "#/components/schemas/impact_line_section_object"
+              - $ref: "#/components/schemas/impact_object_line_section"
         send_notifications:
           description: If notification should be send or not
           type: boolean


### PR DESCRIPTION
# Description

This PR fixes:
Schema '/components/schemas/impact_creation/properties/objects/items/oneOf/1' is defined using the JSONPointer '#/components/schemas/impact_line_section_object' but the target does not exist

## Pull Request type

This is a bug fix

## How to test

Here are the following steps to test this pull request:
check with:
http://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/fix-swagger/documentation/swagger.yml#/Impact/post_disruptions__id__impacts