### PR TITLE
Refs #BOT-1652 cause caonn't be deleted when is used by disruption

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -1229,7 +1229,10 @@ class Disruption(TimestampMixin, db.Model):
             between(get_current_time(), cls.start_publication_date, cls.end_publication_date))
         return query.all()
 
-
+    @classmethod
+    def have_disruption_by_cause_id(cls, cause_id):
+        return cls.query.filter_by(cause_id=cause_id).count() > 0
+       
 associate_impact_pt_object = db.Table(
     'associate_impact_pt_object',
     db.metadata,

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -1262,6 +1262,12 @@ class Cause(flask_restful.Resource):
     @validate_client_token()
     def delete(self, client, id):
         cause = models.Cause.get(id, client.id)
+        if (models.Disruption.have_disruption_by_cause_id(id)):
+            return marshal({
+                'error': {
+                    'message': 'The current {} is linked to at least one disruption and cannot be deleted'.format(cause)
+                }
+            }, error_fields), 409
         cause.is_visible = False
         db.session.commit()
         return None, 204

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -361,6 +361,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error_404"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_occured"
   /channels:
     get:
       description: Retrieves all the channels

--- a/tests/features/deletion-cause.feature
+++ b/tests/features/deletion-cause.feature
@@ -117,3 +117,26 @@ Feature: Cause can be deleted
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "id invalid"
+@test
+    Scenario: deletion cause linked to at least one disruption and cannot be deleted
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | contrib2           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab666-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        When I delete "/causes/7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        Then the status code should be "409"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "The current <Cause '7ffab230-3d48-4eea-aa2c-22f8680230b6'> is linked to at least one disruption and cannot be deleted"


### PR DESCRIPTION
# Description

This PR implement 409 (conflict) message when you delete cause used by one or more disruptions

## Issue 

Issue link: BOT-1676

## How to test

Here are the following steps to test this pull request:

See BOT-1652

## Team reviewers

- [ ] DEV
- [ ] QA
- [ ] PO
