### PR TITLE
Refs #BOT-1707 cause linked only to archived disruptions can be deleted

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -335,7 +335,7 @@ class Cause(TimestampMixin, db.Model):
 
     def is_used_in_disruption(self):
         return db.engine.execute(
-            'SELECT count(*) FROM disruption WHERE cause_id = \'{}\''.format(self.id)
+            'SELECT count(*) FROM disruption WHERE cause_id = \'{}\' AND status != \'archived\''.format(self.id)
         ).scalar() > 0
 
 associate_disruption_tag = db.Table(
@@ -1233,7 +1233,6 @@ class Disruption(TimestampMixin, db.Model):
             between(get_current_time(), cls.start_publication_date, cls.end_publication_date))
         return query.all()
 
-       
 associate_impact_pt_object = db.Table(
     'associate_impact_pt_object',
     db.metadata,
@@ -1245,7 +1244,6 @@ associate_impact_pt_object = db.Table(
         name='impact_pt_object_pk'
     )
 )
-
 
 class Impact(TimestampMixin, db.Model):
     id = db.Column(UUID, primary_key=True)
@@ -2202,7 +2200,7 @@ class Export(TimestampMixin, db.Model):
         for channel in channels.fetchall():
             selectQuery =  selectQuery + 'chmsg' + str(i) + '.text AS "' + channel['channel_name'] + '", '
             leftjoinQuery = (
-                leftjoinQuery + 
+                leftjoinQuery +
                 'LEFT JOIN (' +
                 '   SELECT impact_id, text' +
                 '   FROM message ' +

--- a/tests/features/deletion-cause.feature
+++ b/tests/features/deletion-cause.feature
@@ -118,7 +118,7 @@ Feature: Cause can be deleted
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "id invalid"
 
-    Scenario: deletion cause linked to at least one disruption and cannot be deleted
+    Scenario: cause linked to at least one disruption (not archived) cannot be deleted
         Given I have the following clients in my database:
             | client_code   | created_at          | updated_at          | id                                   |
             | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
@@ -135,8 +135,29 @@ Feature: Cause can be deleted
         Given I have the following disruptions in my database:
             | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
             | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived  | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         When I delete "/causes/7ffab230-3d48-4eea-aa2c-22f8680230b6"
         Then the status code should be "409"
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "The current 'weather' is linked to at least one disruption and cannot be deleted"
+
+    Scenario: cause linked only to archived disruptions can be deleted
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | contrib2           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab666-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        When I delete "/causes/7ffab230-3d48-4eea-aa2c-22f8680230b6"
+        Then the status code should be "204"


### PR DESCRIPTION
# Description

This PR adds deletion of cause when it's linked to only archived disruptions

## Issue 

Issue link: BOT-1707

## Team reviewers

- [ ] DEV
- [ ] QA
- [ ] PO
