### PR TITLE
Task bot 1714 display not archived impacts

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -542,13 +542,15 @@ class Disruption(TimestampMixin, db.Model):
                 'd.id = :disruption_id',
                 'contributor_id = :contributor_id',
                 'c.is_visible = :cause_is_visible',
-                'd.status <> :excluded_disruption_status'
+                'd.status <> :excluded_disruption_status',
+                'i.status <> :excluded_impact_status'
             ],
             'vars':{
                 'disruption_id': id,
                 'contributor_id': contributor_id,
                 'cause_is_visible': True,
-                'excluded_disruption_status': 'archived'
+                'excluded_disruption_status': 'archived',
+                'excluded_impact_status': 'archived'
             },
             'order_by' : {
                 'd.end_publication_date', 'd.id'

--- a/tests/features/disruption-with-author.feature
+++ b/tests/features/disruption-with-author.feature
@@ -49,6 +49,11 @@ Feature: Handle Disruption with author
             | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
             | good news | #654321 | 2019-04-04T23:52:12 | 2019-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status     | id                                   | disruption_id                          |severity_id                            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published  | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7bbab230-3d48-4eea-aa2c-22f8680230b6   |7ffab232-3d48-4eea-aa2c-22f8680230b6   |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published  | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7bbab230-3d48-4eea-aa2c-22f8680230b6   |7ffab232-3d48-4eea-aa2c-22f8680230b6   |
+
         When I get "/disruptions/7bbab230-3d48-4eea-aa2c-22f8680230b6"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -710,111 +710,151 @@ Feature: Manipulate impacts in a Disruption
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "u'' does not match '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$'"
 
-        Scenario: Add an impact in a disruption without objects
+    Scenario: Add an impact in a disruption without objects
 
-	        Given I have the following clients in my database:
-	            | client_code   | created_at          | updated_at          | id                                   |
-	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following contributors in my database:
-	            | contributor_code   | created_at          | updated_at          | id                                   |
-	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following causes in my database:
-	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
-	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following disruptions in my database:
-	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
-	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following severities in my database:
-	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
-	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-
-
-	        I fill in header "X-Customer-Id" with "5"
-	        I fill in header "X-Contributors" with "contrib1"
-	        I fill in header "X-Coverage" with "jdr"
-	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
-	        """
-	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
-	        """
-	        Then the status code should be "400"
-	        And the header "Content-Type" should be "application/json"
-	        And the field "error.message" should be "objects should not be empty"
-
-	    Scenario: Add an impact in a disruption without application_periods
-
-	        Given I have the following clients in my database:
-	            | client_code   | created_at          | updated_at          | id                                   |
-	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-
-	        Given I have the following contributors in my database:
-	            | contributor_code   | created_at          | updated_at          | id                                   |
-	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-
-	        Given I have the following causes in my database:
-	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
-	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
-
-	        Given I have the following disruptions in my database:
-	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
-	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-
-	        Given I have the following severities in my database:
-	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
-	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
 
-	        I fill in header "X-Customer-Id" with "5"
-	        I fill in header "X-Contributors" with "contrib1"
-	        I fill in header "X-Coverage" with "jdr"
-	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
-	        """
-	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_periods": []}
-	        """
-	        Then the status code should be "400"
-	        And the header "Content-Type" should be "application/json"
-	        And the field "error.message" should be "application_periods should not be empty"
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [], "application_periods": [{"begin": "2014-04-29T16:52:00Z","end": "2014-06-22T02:15:00Z"}]}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "objects should not be empty"
+
+    Scenario: Add an impact in a disruption without application_periods
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
 
-	    Scenario: Add an impact in a disruption without application_period_patterns
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_periods": []}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "application_periods should not be empty"
 
-	        Given I have the following clients in my database:
-	            | client_code   | created_at          | updated_at          | id                                   |
-	            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+    Scenario: Add an impact in a disruption without application_period_patterns
 
-	        Given I have the following contributors in my database:
-	            | contributor_code   | created_at          | updated_at          | id                                   |
-	            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following causes in my database:
-	            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
-	            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following disruptions in my database:
-	            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
-	            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
-	            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-	        Given I have the following severities in my database:
-	            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
-	            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | a750994c-01fe-11e4-b4fb-080027079ff3 | 2014-04-15T23:52:12    | 2014-04-19T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
 
-	        I fill in header "X-Customer-Id" with "5"
-	        I fill in header "X-Contributors" with "contrib1"
-	        I fill in header "X-Coverage" with "jdr"
-	        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
-	        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
-	        """
-	        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_period_patterns": []}
-	        """
-	        Then the status code should be "400"
-	        And the header "Content-Type" should be "application/json"
-	        And the field "error.message" should be "application_period_patterns should not be empty"
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Contributors" with "contrib1"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        When I post to "/disruptions/a750994c-01fe-11e4-b4fb-080027079ff3/impacts" with:
+        """
+        {"severity": {"id": "7ffab232-3d48-4eea-aa2c-22f8680230b6"}, "objects": [{"id": "route:JDR:M1","type": "route"}], "application_period_patterns": []}
+        """
+        Then the status code should be "400"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "application_period_patterns should not be empty"
+
+    Scenario: Disruption with archived impacts
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   | client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+
+        Given I have the following disruptions in my database:
+            | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date  |end_publication_date   | cause_id                             |
+            | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00     |2034-02-02 16:52:00    | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                          |severity_id                            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived  | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b1   |7ffab232-3d48-4eea-aa2c-22f8680230b6   |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | archived  | 7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab230-3d48-4eea-aa2c-22f8680230b1   |7ffab232-3d48-4eea-aa2c-22f8680230b6   |
+
+        Given I have the following ptobject in my database:
+            | type          | uri           | created_at          | updated_at          | id                                    |
+            | network       | network:JDR:2 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | 1ffab232-3d48-4eea-aa2c-22f8680230b1  |
+
+        I fill in header "X-Customer-Id" with "5"
+        I fill in header "X-Coverage" with "jdr"
+        I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"
+        I fill in header "X-Contributors" with "contrib1"
+
+        When I get to "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b1":
+        Then the status code should be "404"
+        And the header "Content-Type" should be "application/json"

--- a/tests/features/disruption-with-impacts.feature
+++ b/tests/features/disruption-with-impacts.feature
@@ -836,7 +836,6 @@ Feature: Manipulate impacts in a Disruption
             | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
             | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
 
-
         Given I have the following disruptions in my database:
             | reference  | note   | created_at          | updated_at          | status    | id                                   | client_id                            | contributor_id                       |start_publication_date  |end_publication_date   | cause_id                             |
             | foo1       | hello1 | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b1 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |2014-01-01 16:52:00     |2034-02-02 16:52:00    | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |

--- a/tests/features/list-disruption-with-properties.feature
+++ b/tests/features/list-disruption-with-properties.feature
@@ -34,7 +34,6 @@ Feature: List disruptions with properties
         And the field "disruptions.0.properties.test.0.property.id" should be "f408adec-0243-11e6-954b-0050568c8382"
         And the field "disruptions.0.properties.test.0.value" should be "val2"
 
-
     Scenario: list all disruptions without properties linked to them in database
         Given I have the following clients in my database:
         | client_code | created_at          | updated_at          | id                                   |
@@ -58,28 +57,34 @@ Feature: List disruptions with properties
         And the field "disruptions.0.properties" should be not null
         And the field "disruptions.0.properties" should have a size of 0
 
-
     Scenario: list one disruption with properties linked to it in database
         Given I have the following clients in my database:
-        | client_code | created_at          | updated_at          | id                                   |
-        | test        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | client_code | created_at          | updated_at          | id                                   |
+            | test        | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
         Given I have the following contributors in my database:
-        | contributor_code | created_at          | id                                   |
-        | contributor      | 2014-04-02T23:52:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+            | contributor_code | created_at          | id                                   |
+            | contributor      | 2014-04-02T23:52:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
         Given I have the following causes in my database:
-        | wording | created_at          | is_visible | id                                   | client_id                            |
-        | weather | 2014-04-02T23:52:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | wording | created_at          | is_visible | id                                   | client_id                            |
+            | weather | 2014-04-02T23:52:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2019-04-04T23:52:12 | 2019-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
         Given I have the following disruptions in my database:
-        | reference | note  | created_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date     | end_publication_date  |
-        | foo       | hello | 2014-04-02T23:52:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2019-04-01T00:00:00        | 2019-04-02T00:00:00   |
+            | reference | note  | created_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date     | end_publication_date  |
+            | foo       | hello | 2014-04-02T23:52:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2019-04-01T00:00:00        | 2019-04-02T00:00:00   |
         Given I have the following properties in my database:
-        | created_at          | id                                   | client_id                            | key    | type   |
-        | 2014-04-02T23:52:12 | e408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | key    | type   |
-        | 2014-04-02T23:52:12 | f408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | test   | test   |
+            | created_at          | id                                   | client_id                            | key    | type   |
+            | 2014-04-02T23:52:12 | e408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | key    | type   |
+            | 2014-04-02T23:52:12 | f408adec-0243-11e6-954b-0050568c8382 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | test   | test   |
         Given I have the following associate_disruption_properties in my database:
-        | value | disruption_id                        | property_id                          |
-        | val1  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | e408adec-0243-11e6-954b-0050568c8382 |
-        | val2  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | f408adec-0243-11e6-954b-0050568c8382 |
+            | value | disruption_id                        | property_id                          |
+            | val1  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | e408adec-0243-11e6-954b-0050568c8382 |
+            | val2  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | f408adec-0243-11e6-954b-0050568c8382 |
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status     | id                                   | disruption_id                          |severity_id                            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published  | 7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab230-3d48-4eea-aa2c-22f8680230b6   |7ffab232-3d48-4eea-aa2c-22f8680230b6   |
+
         I fill in header "X-Customer-Id" with "test"
         I fill in header "X-Coverage" with "jdr"
         I fill in header "Authorization" with "d5b0148c-36f4-443c-9818-1f2f74a00be0"

--- a/tests/features/list-disruptions.feature
+++ b/tests/features/list-disruptions.feature
@@ -96,7 +96,7 @@ Feature: list disruptions
         And the field "disruptions.0.publication_period.end" should be "2014-04-02T19:00:00Z"
         And the field "disruptions.1.publication_period.begin" should be "2014-04-02T14:00:00Z"
         And the field "disruptions.1.publication_period.end" should be null
-@test
+
     Scenario: Disruption by id
 
         Given I have the following clients in my database:
@@ -179,6 +179,15 @@ Feature: list disruptions
             | pt_object_id                               | disruption_id                        |
             | 1ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
 
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+
         When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
@@ -219,6 +228,15 @@ Feature: list disruptions
         Given I have the relation associate_disruption_pt_object in my database:
             | pt_object_id                               | disruption_id                        |
             | 1ffab232-3d48-4eea-aa2c-22f8680230b6       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
 
         When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6"
         Then the status code should be "200"

--- a/tests/features/list-disruptions.feature
+++ b/tests/features/list-disruptions.feature
@@ -96,7 +96,7 @@ Feature: list disruptions
         And the field "disruptions.0.publication_period.end" should be "2014-04-02T19:00:00Z"
         And the field "disruptions.1.publication_period.begin" should be "2014-04-02T14:00:00Z"
         And the field "disruptions.1.publication_period.end" should be null
-
+@test
     Scenario: Disruption by id
 
         Given I have the following clients in my database:
@@ -115,6 +115,14 @@ Feature: list disruptions
             | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date | cause_id                             | client_id                            | contributor_id                       |
             | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |  2014-04-02T14:00:00   | None                 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
             | bar       | bye   | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |  2014-04-02T14:00:00   | 2014-04-02T19:00:00  | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
         When I get "/disruptions/7ffab230-3d48-4eea-aa2c-22f8680230b6"
         Then the status code should be "200"

--- a/tests/features/list-disruptions.feature
+++ b/tests/features/list-disruptions.feature
@@ -14,7 +14,7 @@ Feature: list disruptions
         When I get "/disruptions"
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
-        and "disruptions" should be empty
+        And "disruptions" should be empty
 
     Scenario: list of two disruptions
 

--- a/tests/features/update-impact.feature
+++ b/tests/features/update-impact.feature
@@ -627,8 +627,12 @@ Feature: Update (put) impacts in a Disruption
             | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |1          |
 
         Given I have the following severities in my database:
-                | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
-                | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 6a826e64-028f-11e4-92d0-090027079ff3 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
 
         I fill in header "X-Contributors" with "contrib1"
         When I get "/disruptions/6a826e64-028f-11e4-92d0-090027079ff3"


### PR DESCRIPTION
# Description

This PR removes archived impacts from disruption get API

## Issue (optional)

Issue link: BOT-1714

## Pull Request type (optional)

This is a new feature