### PR TITLE
Manage link to impacts when deleted severities

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -190,6 +190,11 @@ class Severity(TimestampMixin, db.Model):
 
         return severity
 
+    def is_used_in_impact(self):
+        return db.engine.execute(
+            'SELECT count(*) FROM impact WHERE severity_id = \'{}\' AND status != \'archived\''.format(self.id)
+        ).scalar() > 0
+
 
 class Category(TimestampMixin, db.Model):
     """

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -141,9 +141,12 @@ class Severity(flask_restful.Resource):
     @validate_id(True)
     @validate_client_token()
     def delete(self, client, id):
-
         try:
             severity = models.Severity.get(id, client.id)
+            if (severity.is_used_in_impact()):
+                error_msg = 'The current \'{}\' is linked to at least one impact and cannot be deleted'.format(severity.wording)
+                logging.getLogger(__name__).warning(error_msg)
+                return marshal({'error': {'message': error_msg}}, error_fields), 409
         except exceptions.ObjectUnknown as e:
             return marshal({'error': {'message': utils.parse_error(e)}},
                            error_fields), 404

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -887,6 +887,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error_occured"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_occured"
   /status:
     get:
       description: Renders state of application
@@ -1855,7 +1861,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error_occured"
-      
+
 servers:
   - url: http://127.0.0.1:5000/
 components:

--- a/tests/features/deletion-severity.feature
+++ b/tests/features/deletion-severity.feature
@@ -143,3 +143,33 @@ Feature: Severity can be deleted
         #client_8 could be able to remove severity created by himself
         When I delete to "/severities/6ffab229-3d48-4eea-aa2c-22f8680230b6":
         Then the status code should be "204"
+
+    Scenario: Severity linked to at least one impact cannot be deleted
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | start_publication_date | end_publication_date     | cause_id                             | client_id                            | contributor_id                       |
+            | toto      |       | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 6a826e64-028f-11e4-92d0-090027079ff3 | 2014-04-20T23:52:12    | 2014-04-30T23:55:12      | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        | severity_id                         |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 6a826e64-028f-11e4-92d0-090027079ff3 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        When I delete "/severities/7ffab232-3d48-4eea-aa2c-22f8680230b6"
+        Then the status code should be "409"
+        And the header "Content-Type" should be "application/json"
+        And the field "error.message" should be "The current 'good news' is linked to at least one impact and cannot be deleted"


### PR DESCRIPTION
# Description

This PR fix the problem of deleting severities when they are already linked to impacts.
Updated doc [here](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/bugfix-bot-1698-delete-severity/documentation/swagger.yml#/Severity/delete_severities__id_)

## Issue

Issue link: BOT-1698, BOT-1849

## How to test

Here are the following steps to test this pull request:

- Create a new severity
- Use it on an impact
- Try to delete the severity
- You should see the error 409
- Delete the impact (or choose another severity for the impact)
- Try to delete the severity
- It should work

## Validation steps

- [x] DEV
- [x] QA
