### PR TITLE
[docker] patch UWSGI to allow http 'chunked'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ EXPOSE 5000
 
 ENV CHAOS_CONFIG_FILE=default_settings.py
 ENV PYTHONPATH=.
-CMD ["uwsgi", "--mount", "/=chaos:app", "--http", "0.0.0.0:5000"]
+CMD ["uwsgi", "--mount", "/=chaos:app", "--http", "0.0.0.0:5000", "--http-chunked-in"]


### PR DESCRIPTION
# Description

This PR fixes :

`
app.ERROR: [curl] 55: Send failure: Broken pipe [url] http://172.18.0.3:5000/causes/52c...`
when NMM 'app_test_rt.php' tries to PUT or POST something to container ` chaos-ws`

## Issue (optional)

BOT-2031