### PR TITLE
[Docker] Fixing setuptools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -xe && \
     pip install --upgrade pip && \
     pip install uwsgi -i https://pypi.org/simple/ && \
     pip install setuptools==44.1.0 && \
-    pip install -r requirements.txt -i https://pypi.python.org/simple/ && \
+    pip install -r requirements.txt -i https://pypi.org/simple/ && \
     python setup.py build_pbf && cd .. && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yq install $buildDeps && \
     pip install --upgrade pip && \
-    pip install uwsgi -i https://pypi.python.org/simple/ && \
+    pip install uwsgi -i https://pypi.org/simple/ && \
     pip install setuptools==44.1.0 && \
     pip install -r requirements.txt -i https://pypi.python.org/simple/ && \
     python setup.py build_pbf && cd .. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN set -xe && \
     buildDeps="libpq-dev python-dev protobuf-compiler git" && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yq install $buildDeps && \
+    pip install --upgrade pip && \
     pip install uwsgi -i https://pypi.python.org/simple/ && \
-    pip install --upgrade setuptools pip && \
+    pip install setuptools==44.1.0 && \
     pip install -r requirements.txt -i https://pypi.python.org/simple/ && \
     python setup.py build_pbf && cd .. && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps && \


### PR DESCRIPTION
# Description

This PR fixes setuptools version to 44.1.0 for python 2.7, to avoid error :
```
...
 File "setuptools/__init__.py", line 21, in <module>
    import setuptools.version
  File "setuptools/version.py", line 1, in <module>
    import pkg_resources
  File "pkg_resources/__init__.py", line 1380

    raise SyntaxError(e) from e
```