### PR TITLE
Fix empty pt object filter on impacts/_search API

### DIFF
--- a/chaos/models.py
+++ b/chaos/models.py
@@ -760,18 +760,20 @@ class Disruption(TimestampMixin, db.Model):
                 vars['uri_like'] = uri + ':%'
             andwheres.append('(' + ' OR '.join(uri_filters) + ')')
         elif ptObjectFilter is not None:
-            uri_filters = []
-            uri_filters.append('po.uri IN :pt_objects_uris')
-            bindparams['pt_objects_uris'] = db.String
-            vars['pt_objects_uris'] = tuple([id for ids in ptObjectFilter.itervalues() for id in ids])
+            ptObjectIds = [id for ids in ptObjectFilter.itervalues() for id in ids]
+            if ptObjectIds:
+                uri_filters = []
+                uri_filters.append('po.uri IN :pt_objects_uris')
+                bindparams['pt_objects_uris'] = db.String
+                vars['pt_objects_uris'] = tuple(ptObjectIds)
 
-            if line_section and 'lines' in ptObjectFilter:
-                uri_filters.append('(po.type = :po_type_line_section AND po_line.uri IN :po_line_section_lines)')
-                bindparams['po_type_line_section'] = db.String
-                bindparams['po_line_section_lines'] = db.String
-                vars['po_type_line_section'] = 'line_section'
-                vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
-            andwheres.append('(' + ' OR '.join(uri_filters) + ')')
+                if line_section and 'lines' in ptObjectFilter and ptObjectFilter['lines']:
+                    uri_filters.append('(po.type = :po_type_line_section AND po_line.uri IN :po_line_section_lines)')
+                    bindparams['po_type_line_section'] = db.String
+                    bindparams['po_line_section_lines'] = db.String
+                    vars['po_type_line_section'] = 'line_section'
+                    vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
+                andwheres.append('(' + ' OR '.join(uri_filters) + ')')
 
         if isinstance(cause_category_id, basestring) and cause_category_id:
             andwheres.append('c.category_id = :cause_category_id')
@@ -1480,18 +1482,20 @@ class Impact(TimestampMixin, db.Model):
         bindparams['cause_is_visisble'] = db.Boolean
 
         if ptObjectFilter is not None:
-            uri_filters = []
-            uri_filters.append('po.uri IN :pt_objects_uris')
-            bindparams['pt_objects_uris'] = db.String
-            vars['pt_objects_uris'] = tuple([id for ids in ptObjectFilter.itervalues() for id in ids])
+            ptObjectIds = [id for ids in ptObjectFilter.itervalues() for id in ids]
+            if ptObjectIds :
+                uri_filters = []
+                uri_filters.append('po.uri IN :pt_objects_uris')
+                bindparams['pt_objects_uris'] = db.String
+                vars['pt_objects_uris'] = tuple(ptObjectIds)
 
-            if 'lines' in ptObjectFilter:
-                uri_filters.append('(po.type = :po_type_line_section AND po_line.uri IN :po_line_section_lines)')
-                bindparams['po_type_line_section'] = db.String
-                bindparams['po_line_section_lines'] = db.String
-                vars['po_type_line_section'] = 'line_section'
-                vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
-            andwheres.append('(' + ' OR '.join(uri_filters) + ')')
+                if 'lines' in ptObjectFilter and ptObjectFilter['lines']:
+                    uri_filters.append('(po.type = :po_type_line_section AND po_line.uri IN :po_line_section_lines)')
+                    bindparams['po_type_line_section'] = db.String
+                    bindparams['po_line_section_lines'] = db.String
+                    vars['po_type_line_section'] = 'line_section'
+                    vars['po_line_section_lines'] = tuple(ptObjectFilter['lines'])
+                andwheres.append('(' + ' OR '.join(uri_filters) + ')')
 
         if isinstance(cause_category_id, basestring) and cause_category_id:
             andwheres.append('c.category_id = :cause_category_id')

--- a/tests/features/post-impacts-search.feature
+++ b/tests/features/post-impacts-search.feature
@@ -167,7 +167,7 @@ Feature: list disruptions with ptObjects filter
 
         Given I have the following applicationperiods in my database:
             | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
-            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-04-10 16:52:00                  |2014-04-30 16:52:00 |                 |2014-01-30 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-04-10 16:52:00                  |2014-04-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b5 | 7ffab234-3d49-4eea-aa2c-22f8680230b3 |2014-04-10 16:52:00                  |2014-04-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab234-3d49-4eec-aa2c-22f8680230b4 |2014-04-10 16:52:00                  |2014-04-30 16:52:00 |
             | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b7 | 7ffab234-3d49-4eec-aa2c-22f8680230b5 |2014-04-10 16:52:00                  |2014-04-30 16:52:00 |
@@ -479,7 +479,6 @@ Feature: list disruptions with ptObjects filter
         Then the status code should be "400"
         And the header "Content-Type" should be "application/json"
         And the field "message" should be "items_per_page argument value can't be superior than 1000"
-
 
     Scenario: Test if about body when ptObjectFilter is not added
         Given I have the following clients in my database:
@@ -935,3 +934,53 @@ Feature: list disruptions with ptObjects filter
         Then the status code should be "200"
         And the header "Content-Type" should be "application/json"
         And the field "impacts" should have a size of 4
+
+    Scenario: When pt object filter elemnts are empty this filter is ignored
+
+        Given I have the following clients in my database:
+            | client_code   | created_at          | updated_at          | id                                   |
+            | 5             | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following causes in my database:
+            | wording   | created_at          | updated_at          | is_visible | id                                   |client_id                             |
+            | weather   | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | True       | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following contributors in my database:
+            | contributor_code   | created_at          | updated_at          | id                                   |
+            | contrib1           | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following disruptions in my database:
+            | reference | note  | created_at          | updated_at          | status    | id                                   | cause_id                             | client_id                            | contributor_id                       | start_publication_date | end_publication_date |
+            | foo       | hello | 2014-04-02T23:52:12 | 2014-04-02T23:55:12 | published | 7ffab230-3d48-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f868023042 | 7ffab229-3d48-4eea-aa2c-22f8680230b6 | 7ffab555-3d48-4eea-aa2c-22f8680230b6 | 2014-04-10T23:42:00    | 2014-04-20T23:42:00  |
+
+        Given I have the following severities in my database:
+            | wording   | color   | created_at          | updated_at          | is_visible | id                                   |client_id                            |
+            | good news | #654321 | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | True       | 7ffab232-3d48-4eea-aa2c-22f8680230b6 |7ffab229-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following impacts in my database:
+            | created_at          | updated_at          | status    | id                                   | disruption_id                        |severity_id                          |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b6 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 | published | 7ffab232-3d47-4eea-aa2c-22f8680230b7 | 7ffab230-3d48-4eea-aa2c-22f8680230b6 |7ffab232-3d48-4eea-aa2c-22f8680230b6 |
+
+        Given I have the following ptobject in my database:
+            | type  | uri           | created_at          | id                                         |
+            | line  | line:JDR:M1   | 2014-04-04T23:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b6       |
+            | line  | line:JDR:M2   | 2014-04-06T22:52:12 | 3ffab232-3d48-4eea-aa2c-22f8680230b7       |
+
+        Given I have the relation associate_impact_pt_object in my database:
+            | pt_object_id                                  | impact_id                            |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b6          | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |
+            | 3ffab232-3d48-4eea-aa2c-22f8680230b7          | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |
+
+        Given I have the following applicationperiods in my database:
+            | created_at          | updated_at          |id                                   | impact_id                            |start_date                           |end_date            |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b1 | 7ffab232-3d47-4eea-aa2c-22f8680230b6 |2014-04-10 16:52:00                  |2014-04-17 16:52:00 |
+            | 2014-04-04T23:52:12 | 2014-04-06T22:52:12 |7ffab232-3d47-4eea-aa2c-22f8680230b2 | 7ffab232-3d47-4eea-aa2c-22f8680230b7 |2014-04-10 16:52:00                  |2014-04-17 16:52:00 |
+
+        When I post to "/impacts/_search" with:
+        """
+        {"current_time": "2014-04-15T14:00:00Z", "application_status":["ongoing"], "ptObjectFilter": {"lines": []}}
+        """
+        Then the status code should be "200"
+        And the header "Content-Type" should be "application/json"
+        And the field "impacts" should have a size of 2


### PR DESCRIPTION
# Description

This PR fixes filter issue on impacts/_search API when ptobject list is empty

## Issue (optional)

Issue link: BOT-2039

## Pull Request type (optional)

This is a bug fix