### PR TITLE
[doc] rail_section init

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2609,6 +2609,7 @@ components:
                 required:
                   - id
                   - order
+              minItems: 1
             route_patterns:
               type: array
               items:
@@ -2624,6 +2625,8 @@ components:
                   required:
                     - id
                     - order
+                minItems: 2
+              minItems: 1
             line:
               type: object
               properties:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2604,9 +2604,8 @@ components:
                   id:
                     type: string
                   order:
-                    type: string
-                    enum:
-                      - integer
+                    type: integer
+                    minimum: 0
                 required:
                   - id
                   - order

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2553,6 +2553,84 @@ components:
             - start_point
             - end_point
             - line
+    impact_object_rail_section:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          description: Impacted PT object ID in navitia
+          type: string
+          maxLength: 250
+        type:
+          description: Impacted PT object type in navitia
+          type: string
+          enum:
+            - rail_section
+      rail_section:
+          type: object
+          properties:
+            start_point:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - stop_area
+              required:
+                - id
+                - type
+            end_point:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - stop_area
+              required:
+                - id
+                - type
+            blocked_stop_areas:
+              type: array
+                items:
+                  description: Id of stop_area object
+                  type: string
+            route_patterns:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - route
+                required:
+                  - id
+                  - type
+            line:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - line
+              required:
+                - id
+                - type
+          required:
+            - start_point
+            - end_point
+            - blocked_stop_areas
+            - line
     disruption_impact_message:
       type: object
       required:
@@ -2953,6 +3031,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
         send_notifications:
           description: If notification should be send or not
           type: boolean

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2568,7 +2568,7 @@ components:
           type: string
           enum:
             - rail_section
-      rail_section:
+        rail_section:
           type: object
           properties:
             start_point:
@@ -2597,23 +2597,34 @@ components:
                 - type
             blocked_stop_areas:
               type: array
-                items:
-                  description: Id of stop_area object
-                  type: string
-            route_patterns:
-              type: array
               items:
                 type: object
                 properties:
                   id:
                     type: string
-                  type:
+                  order:
                     type: string
                     enum:
-                      - route
+                      - integer
                 required:
                   - id
-                  - type
+                  - order
+            route_patterns:
+              type: array
+              items:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    order:
+                      type: string
+                      enum:
+                        - integer
+                  required:
+                    - id
+                    - order
             line:
               type: object
               properties:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2644,7 +2644,6 @@ components:
             - end_point
             - blocked_stop_areas
             - route_patterns
-            - line
     disruption_impact_message:
       type: object
       required:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2619,9 +2619,8 @@ components:
                     id:
                       type: string
                     order:
-                      type: string
-                      enum:
-                        - integer
+                      type: integer
+                      minimum: 0
                   required:
                     - id
                     - order

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2456,6 +2456,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
           uniqueItems: true
           minItems: 1
     impact_object:
@@ -2805,6 +2806,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
           uniqueItems: true
           minItems: 1
     disruption_in_impact:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2640,6 +2640,7 @@ components:
             - start_point
             - end_point
             - blocked_stop_areas
+            - route_patterns
             - line
     disruption_impact_message:
       type: object


### PR DESCRIPTION
This PR adds rail_section format example in swagger documentation

ref: bot-2416

You can read the result
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/doc-swagger-rail-section-bot-2416/documentation/swagger.yml