### PR TITLE
[Doc] railsection route_patterns example

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2678,6 +2678,11 @@ components:
                   required:
                     - id
                     - order
+                example:
+                  - id: string
+                    order: 0
+                  - id: string
+                    order: 1
                 minItems: 2
               minItems: 1
             line:


### PR DESCRIPTION
# Description

This PR adds doc according to rail section mandatory infos

https://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/patch-doc-railsection-min-mandatory/documentation/swagger.yml#/Impact/post_disruptions__id__impacts