### PR TITLE
Refs #BOT-2625 - Swagger updated, to add rail_section type.

### DIFF
--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2509,6 +2509,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
           uniqueItems: true
           minItems: 1
     impact_object:
@@ -2606,6 +2607,97 @@ components:
             - start_point
             - end_point
             - line
+    impact_object_rail_section:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          description: Impacted PT object ID in navitia
+          type: string
+          maxLength: 250
+        type:
+          description: >
+            Impacted PT object type in navitia (BETA version)
+
+            "routes" or "line" property are mandatory.
+
+            If both are specified, "line" will be ignored. Only "routes" will be kept.
+          type: string
+          enum:
+            - rail_section
+        rail_section:
+          type: object
+          properties:
+            start_point:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - stop_area
+              required:
+                - id
+                - type
+            end_point:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - stop_area
+              required:
+                - id
+                - type
+            blocked_stop_areas:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  order:
+                    type: integer
+                    minimum: 0
+                required:
+                  - id
+                  - order
+              minItems: 1
+            routes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  type:
+                    type: string
+                    enum:
+                      - route
+                required:
+                  - id
+                  - type
+            line:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                    - line
+              required:
+                - id
+                - type
+          required:
+            - start_point
+            - end_point
+            - blocked_stop_areas
     disruption_impact_message:
       type: object
       required:
@@ -2769,6 +2861,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
           uniqueItems: true
           minItems: 1
     disruption_in_impact:
@@ -3006,6 +3099,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/impact_object"
               - $ref: "#/components/schemas/impact_object_line_section"
+              - $ref: "#/components/schemas/impact_object_rail_section"
         send_notifications:
           description: If notification should be send or not
           type: boolean

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2625,7 +2625,6 @@ components:
         rail_section:
           title: >
             "routes" or "line" property are mandatory.
-            If both are specified, "line" will be ignored. Only "routes" will be kept.
           type: object
           properties:
             start_point:

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2618,16 +2618,14 @@ components:
           type: string
           maxLength: 250
         type:
-          description: >
-            Impacted PT object type in navitia (BETA version)
-
-            "routes" or "line" property are mandatory.
-
-            If both are specified, "line" will be ignored. Only "routes" will be kept.
+          description: Impacted PT object type in navitia (BETA version)
           type: string
           enum:
             - rail_section
         rail_section:
+          title: >
+            "routes" or "line" property are mandatory.
+            If both are specified, "line" will be ignored. Only "routes" will be kept.
           type: object
           properties:
             start_point:


### PR DESCRIPTION
# Description

This PR update swagger file to add rail_section type.

see [here](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/CanalTP/Chaos/task_BOT-2625_rail_section_swagger/documentation/swagger.yml) for the swagger

## Issue

- https://jira.kisio.org/browse/BOT-2625

## Pull Request type (optional)

This is for a new feature (documentation only)
