### PR TITLE
Make id not required on rail_section object

### DIFF
--- a/chaos/db_helper.py
+++ b/chaos/db_helper.py
@@ -159,7 +159,10 @@ def fill_and_add_rail_section(navitia, all_objects, pt_object_json):
     :return: pt_object and modify all_objects param
     """
     ptobject = models.PTobject()
-    mapper.fill_from_json(ptobject, pt_object_json, mapper.object_mapping)
+    if 'rail_section' in pt_object_json:
+        mapper.fill_from_json(ptobject, pt_object_json, mapper.rail_section_object_mapping)
+    else:
+        mapper.fill_from_json(ptobject, pt_object_json, mapper.object_mapping)
 
     # Here we treat all the objects in rail_section like line, start_point, end_point
     if 'rail_section' not in pt_object_json:

--- a/chaos/formats.py
+++ b/chaos/formats.py
@@ -16,12 +16,10 @@ pt_object_type_values = [
     "stop_area",
     "line",
     "route",
-    "stop_point",
-    "rail_section"
+    "stop_point"
 ]
-complete_pt_object_type_values = [
-    "line_section"
-]
+pt_object_type_line_section = ["line_section"]
+pt_object_type_rail_section = ["rail_section"]
 # Here Order of values is strict and is used to create query filters.
 application_status_values = ["past", "ongoing", "coming"]
 publication_status_values = ["past", "ongoing", "coming"]
@@ -138,8 +136,7 @@ object_input_format = {
     'type': 'object',
     'properties': {
         'id': {'type': 'string', 'maxLength': 250},
-        'type': {'enum': pt_object_type_values},
-        'rail_section': rail_section_format
+        'type': {'enum': pt_object_type_values}
     },
     'required': ['id', 'type']
 }
@@ -148,8 +145,19 @@ line_section_input_format = {
     'type': 'object',
     'properties': {
         'id': {'type': 'string', 'maxLength': 250},
-        'type': {'enum': complete_pt_object_type_values},
+        'type': {'enum': pt_object_type_line_section},
         'line_section': line_section_format
+    },
+    'required': ['type']
+}
+
+
+rail_section_input_format = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'string', 'maxLength': 250},
+        'type': {'enum': pt_object_type_rail_section},
+        'rail_section': rail_section_format
     },
     'required': ['type']
 }
@@ -344,7 +352,8 @@ impact_input_format = {
             'items': {
                 'anyOf':[
                     object_input_format,
-                    line_section_input_format
+                    line_section_input_format,
+                    rail_section_input_format
                 ]
             },
             'uniqueItems': True,

--- a/chaos/formats.py
+++ b/chaos/formats.py
@@ -151,7 +151,6 @@ line_section_input_format = {
     'required': ['type']
 }
 
-
 rail_section_input_format = {
     'type': 'object',
     'properties': {

--- a/chaos/mapper.py
+++ b/chaos/mapper.py
@@ -127,11 +127,9 @@ line_section_object_mapping = {
     "type": None
 }
 
-
 rail_section_object_mapping = {
     "type": None
 }
-
 
 message_mapping = {
     "text": None,

--- a/chaos/mapper.py
+++ b/chaos/mapper.py
@@ -127,6 +127,12 @@ line_section_object_mapping = {
     "type": None
 }
 
+
+rail_section_object_mapping = {
+    "type": None
+}
+
+
 message_mapping = {
     "text": None,
     'channel': {'id': AliasText(attribute='channel_id')}

--- a/chaos/resources.py
+++ b/chaos/resources.py
@@ -10,8 +10,8 @@ from jsonschema import validate, ValidationError
 from flask.ext.restful import abort
 from fields import *
 from formats import *
-from formats import impact_input_format, channel_input_format, pt_object_type_values, complete_pt_object_type_values,\
-    tag_input_format, category_input_format, channel_type_values,\
+from formats import impact_input_format, channel_input_format, pt_object_type_values, pt_object_type_line_section,\
+    pt_object_type_rail_section, tag_input_format, category_input_format, channel_type_values,\
     property_input_format, disruptions_search_input_format, application_status_values, \
     impacts_search_input_format, export_input_format, contributor_input_format
 from chaos import mapper, exceptions
@@ -1150,7 +1150,7 @@ class ImpactsByObject(flask_restful.Resource):
         self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser()
         parser_get = self.parsers["get"]
-        parser_get.add_argument("pt_object_type", type=option_value(pt_object_type_values + complete_pt_object_type_values))
+        parser_get.add_argument("pt_object_type", type=option_value(pt_object_type_values + pt_object_type_line_section + pt_object_type_rail_section))
         parser_get.add_argument("start_date", type=utils.get_datetime, default=default_start_date)
         parser_get.add_argument("end_date", type=utils.get_datetime, default=default_end_date)
         parser_get.add_argument("uri[]", type=str, action="append")

--- a/documentation/swagger.yml
+++ b/documentation/swagger.yml
@@ -2609,7 +2609,6 @@ components:
     impact_object_rail_section:
       type: object
       required:
-        - id
         - type
       properties:
         id:

--- a/tests/features/create-disruption-with-rail-section.feature
+++ b/tests/features/create-disruption-with-rail-section.feature
@@ -68,3 +68,21 @@ Feature: Create Disruption with rail section
         And the header "Content-Type" should be "application/json"
         And the field "error.message" should be "{u'rail_section': {u'line': {u'type': u'line', u'id': u'line:JDR:M5'}, u'start_point': {u'type': u'stop_area', u'id': u'stop_area:JDR:CHVIN'}}, u'type': u'rail_section', u'id': u'stop_area:JDR:BASTI:stop_area:JDR:CHVIN:1'} is not valid under any of the given schemas"
 
+    Scenario: creation of disruption with one impact and ptobject rail_section with line without routes
+        When I post to "/disruptions" with:
+        """
+        {"reference":"foo","contributor":"contrib1","cause":{"id":"7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts":[{"severity":{"id":"7ffab232-3d48-4eea-aa2c-22f8680230b6"},"application_periods":[{"begin":"2014-04-29T16:52:00Z","end":"2014-06-22T02:15:00Z"},{"begin":"2014-04-29T16:52:00Z","end":"2014-05-22T02:15:00Z"}],"objects":[{"id":"stop_area:JDR:BASTI:stop_area:JDR:CHVIN:1","type":"rail_section","rail_section":{"line":{"id":"line:JDR:M5","type":"line"},"start_point":{"id":"stop_area:JDR:BASTI","type":"stop_area"},"end_point":{"id":"stop_area:JDR:CHVIN","type":"stop_area"},"blocked_stop_areas":[{"id":"stop_area:1","order":0}]}}]}]}
+        """
+        Then the status code should be "201"
+        And the header "Content-Type" should be "application/json"
+        And the field "disruption.impacts.pagination.total_result" should be 1
+        And the field "disruption.version" should be 1
+        And the field "disruption.impacts.impacts" should not exist
+
+    Scenario: creation of disruption with one impact and ptobject rail_section without id
+        When I post to "/disruptions" with:
+        """
+        {"reference":"foo","contributor":"contrib1","cause":{"id":"7ffab230-3d48-4eea-aa2c-22f8680230b6"},"publication_period":{"begin":"2018-09-11T13:50:00Z","end":"2018-12-31T16:50:00Z"},"impacts":[{"severity":{"id":"7ffab232-3d48-4eea-aa2c-22f8680230b6"},"application_periods":[{"begin":"2014-04-29T16:52:00Z","end":"2014-06-22T02:15:00Z"},{"begin":"2014-04-29T16:52:00Z","end":"2014-05-22T02:15:00Z"}],"objects":[{"type":"rail_section","rail_section":{"line":{"id":"line:JDR:M5","type":"line"},"start_point":{"id":"stop_area:JDR:BASTI","type":"stop_area"},"end_point":{"id":"stop_area:JDR:CHVIN","type":"stop_area"},"blocked_stop_areas":[{"id":"stop_area:1","order":0}],"routes":[{"id":"route:FLY:D_MRS","type":"route"},{"id":"route:FLY:D_VCE","type":"route"}]}}]}]}
+        """
+        Then the status code should be "201"
+        And the header "Content-Type" should be "application/json"

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -405,33 +405,33 @@ def test_impact_with_line_section_with_route_and_metas_value_not_exist():
 
 def test_impact_with_rail_section_validation():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"line":{"id":"line:AME:3","type":"line"}, "start_point":{"id":"stop_area:MTD:SA:154", "type":"stop_area"},	"end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 @raises(ValidationError)
 def test_impact_with_rail_section_without_end_point_validation():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"line": {"id": "line:AME:3", "type": "line"}, "start_point": {"id": "stop_area:MTD:SA:154", "type": "stop_area"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}], "route_patterns": [[{"id": "stop_area:DUA:SA:8775810", "order": 1}, {"id": "stop_area:DUA:SA:8775810", "order": 2}]]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 @raises(ValidationError)
 def test_impact_with_rail_section_and_line_type_invalid():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"line":{"id":"line:AME:3","type":"stop_area"}, "start_point":{"id":"stop_area:MTD:SA:154", "type":"stop_area"},	"end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 @raises(ValidationError)
 def test_impact_with_rail_section_and_start_point_type_invalid():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"line":{"id":"line:AME:3","type":"line"}, "start_point":{"id":"stop_area:MTD:SA:154", "type":"stop_point"},	"end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 
 @raises(ValidationError)
 def test_impact_with_rail_section_and_end_point_type_invalid():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"line":{"id":"line:AME:3","type":"line"}, "start_point":{"id":"stop_area:MTD:SA:154", "type":"stop_area"},	"end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"line"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 
 def test_impact_with_rail_section_without_line_validation():
     json = {'id': 'line:AME:3', 'type': 'rail_section', "rail_section": {"start_point":{"id":"stop_area:MTD:SA:154", "type":"stop_area"},	"end_point":{"id":"stop_area:JDR:SA:CHVIN", "type":"stop_area"}, "blocked_stop_areas": [{"id": "stop_area:DUA:SA:8775810", "order": 1}], "routes":[{"type":"route", "id":"route:JDR:M14"}, {"type":"route", "id":"route:JDR:M1"}]}}
-    validate(json, formats.object_input_format)
+    validate(json, formats.rail_section_input_format)
 
 
 def test_time_slot_input_format_valid():


### PR DESCRIPTION
# Description

This PR makes id not required on rail_section object

## Issue

Issue link:bot-2773


## How to test

Here are the following steps to test this pull request:

- create disruption with rail_section with or without id should be functional
